### PR TITLE
Add Simplified Chinese (zh_CN) translation

### DIFF
--- a/translations/rpgmtranslate.zh_CN.ts
+++ b/translations/rpgmtranslate.zh_CN.ts
@@ -1,0 +1,3007 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>AboutWindow</name>
+    <message>
+        <location filename="../src/AboutWindow/AboutWindow.ui" line="35"/>
+        <source>About RPGMTranslate</source>
+        <translation>关于 RPGMTranslate</translation>
+    </message>
+    <message>
+        <location filename="../src/AboutWindow/AboutWindow.ui" line="128"/>
+        <source>RPGMTranslate is licensed under [WTFPL](https://www.wtfpl.net/).</source>
+        <translation>RPGMTranslate 采用 [WTFPL](https://www.wtfpl.net/) 许可证。</translation>
+    </message>
+    <message>
+        <location filename="../src/AboutWindow/AboutWindow.ui" line="141"/>
+        <source>The program uses third-party software, that is licensed under other conditions:
+- [Google Material Symbols](https://fonts.google.com/icons) - licensed under `Apache License Version 2.0`.
+- [jeaiii/itoa](https://github.com/jeaiii/itoa) - licensed under MIT.
+- [miniaudio](https://github.com/mackron/miniaudio) - public domain.
+- [magic_enum](https://github.com/Neargye/magic_enum) - licensed under MIT.
+- [zmij](https://github.com/vitaut/zmij) - licensed under MIT.</source>
+        <translation>本程序使用了以下第三方软件，它们采用不同的许可证：
+- [Google Material Symbols](https://fonts.google.com/icons) - 采用 `Apache License Version 2.0`。
+- [jeaiii/itoa](https://github.com/jeaiii/itoa) - 采用 MIT 许可证。
+- [miniaudio](https://github.com/mackron/miniaudio) - 公有领域。
+- [magic_enum](https://github.com/Neargye/magic_enum) - 采用 MIT 许可证。
+- [zmij](https://github.com/vitaut/zmij) - 采用 MIT 许可证。</translation>
+    </message>
+    <message>
+        <location filename="../src/AboutWindow/AboutWindow.ui" line="159"/>
+        <source>GitHub: [rpgmtranslate-qt](https://github.com/RPG-Maker-Translation-Tools/rpgmtranslate-qt)</source>
+        <translation>GitHub: [rpgmtranslate-qt](https://github.com/RPG-Maker-Translation-Tools/rpgmtranslate-qt)</translation>
+    </message>
+</context>
+<context>
+    <name>AssetMenu</name>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="39"/>
+        <source>Search file...</source>
+        <translation>搜索文件...</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="123"/>
+        <source>Audio</source>
+        <translation>音频</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="124"/>
+        <source>Data</source>
+        <translation>数据</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="125"/>
+        <source>Images</source>
+        <translation>图片</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="126"/>
+        <source>Icons</source>
+        <translation>图标</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="127"/>
+        <source>Fonts</source>
+        <translation>字体</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="128"/>
+        <source>Movies</source>
+        <translation>视频</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="129"/>
+        <source>JS</source>
+        <translation>JS</translation>
+    </message>
+</context>
+<context>
+    <name>AssetPreviewWidget</name>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="41"/>
+        <source>Locate file</source>
+        <translation>定位文件</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="42"/>
+        <source>Open in default app</source>
+        <translation>在默认应用中打开</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="45"/>
+        <source>Beautify</source>
+        <translation>美化</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="111"/>
+        <source>Media playback not available</source>
+        <translation>媒体播放不可用</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="123"/>
+        <source>The quick brown fox jumps over the lazy dog</source>
+        <translation>敏捷的棕色狐狸跳过了懒狗</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="127"/>
+        <source> pt</source>
+        <translation> 磅</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="270"/>
+        <source>Highlighting is disabled</source>
+        <translation>语法高亮已禁用</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="271"/>
+        <source>JSON highlighting was disabled during compilation.</source>
+        <translation>JSON 语法高亮在编译时被禁用。</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="328"/>
+        <source>Extension is unsupported.</source>
+        <translation>不支持该扩展名。</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="374"/>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="566"/>
+        <source>Failed to decrypt asset %1: %2</source>
+        <translation>解密资源 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="388"/>
+        <source>Failed to load pixmap from %1</source>
+        <translation>从 %1 加载像素图失败</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="410"/>
+        <source>Failed to load font %1</source>
+        <translation>加载字体 %1 失败</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="428"/>
+        <source>Any</source>
+        <translation>任意</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="431"/>
+        <source>Latin</source>
+        <translation>拉丁文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="434"/>
+        <source>Greek</source>
+        <translation>希腊文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="437"/>
+        <source>Cyrillic</source>
+        <translation>西里尔文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="440"/>
+        <source>Armenian</source>
+        <translation>亚美尼亚文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="443"/>
+        <source>Hebrew</source>
+        <translation>希伯来文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="446"/>
+        <source>Arabic</source>
+        <translation>阿拉伯文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="449"/>
+        <source>Syriac</source>
+        <translation>叙利亚文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="452"/>
+        <source>Thaana</source>
+        <translation>塔安娜文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="455"/>
+        <source>Devanagari</source>
+        <translation>天城文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="458"/>
+        <source>Bengali</source>
+        <translation>孟加拉文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="461"/>
+        <source>Gurmukhi</source>
+        <translation>古木基文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="464"/>
+        <source>Gujarati</source>
+        <translation>古吉拉特文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="467"/>
+        <source>Oriya</source>
+        <translation>奥里亚文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="470"/>
+        <source>Tamil</source>
+        <translation>泰米尔文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="473"/>
+        <source>Telugu</source>
+        <translation>泰卢固文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="476"/>
+        <source>Kannada</source>
+        <translation>卡纳达文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="479"/>
+        <source>Malayalam</source>
+        <translation>马拉雅拉姆文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="482"/>
+        <source>Sinhala</source>
+        <translation>僧伽罗文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="485"/>
+        <source>Thai</source>
+        <translation>泰文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="488"/>
+        <source>Lao</source>
+        <translation>老挝文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="491"/>
+        <source>Tibetan</source>
+        <translation>藏文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="494"/>
+        <source>Myanmar</source>
+        <translation>缅甸文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="497"/>
+        <source>Georgian</source>
+        <translation>格鲁吉亚文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="500"/>
+        <source>Khmer</source>
+        <translation>高棉文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="503"/>
+        <source>Simplified Chinese</source>
+        <translation>简体中文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="506"/>
+        <source>Traditional Chinese</source>
+        <translation>繁体中文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="509"/>
+        <source>Japanese</source>
+        <translation>日文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="512"/>
+        <source>Korean</source>
+        <translation>韩文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="515"/>
+        <source>Vietnamese</source>
+        <translation>越南文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="518"/>
+        <source>Symbol</source>
+        <translation>符号</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="521"/>
+        <source>Ogham</source>
+        <translation>欧甘文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="524"/>
+        <source>Runic</source>
+        <translation>如尼文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="527"/>
+        <source>Nko</source>
+        <translation>恩科文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="535"/>
+        <source>Supported writing systems: </source>
+        <translation>支持的书写系统：</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="583"/>
+        <source>Failed to open temporary file %1: %2</source>
+        <translation>打开临时文件 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="613"/>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="630"/>
+        <source>Asset playback is disabled. You can open asset in the default app.</source>
+        <translation>资源播放已禁用。您可以在默认应用中打开资源。</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="648"/>
+        <source>Failed to open file %1: %2</source>
+        <translation>打开文件 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="678"/>
+        <source>Failed to generate JSON</source>
+        <translation>生成 JSON 失败</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="679"/>
+        <source>Failed to generate JSON for file %1: %2</source>
+        <translation>为文件 %1 生成 JSON 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="774"/>
+        <source>Invalid regex</source>
+        <translation>无效的正则表达式</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="798"/>
+        <source>No results</source>
+        <translation>无结果</translation>
+    </message>
+</context>
+<context>
+    <name>BackupSelectDialog</name>
+    <message>
+        <location filename="../src/BackupSelectDialog/BackupSelectDialog.hpp" line="25"/>
+        <source>Load</source>
+        <translation>加载</translation>
+    </message>
+    <message>
+        <location filename="../src/BackupSelectDialog/BackupSelectDialog.hpp" line="26"/>
+        <source>Once you click load, your current progress will be LOST! All current changed will be overwritten by a backup and the project will be reloaded.</source>
+        <translation>点击加载后，当前进度将丢失！所有当前更改将被备份覆盖，项目将重新加载。</translation>
+    </message>
+    <message>
+        <location filename="../src/BackupSelectDialog/BackupSelectDialog.hpp" line="64"/>
+        <source>This backup was created %1.</source>
+        <translation>此备份创建于 %1。</translation>
+    </message>
+</context>
+<context>
+    <name>BatchMenu</name>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="54"/>
+        <source>- Batch Action -</source>
+        <translation>- 批量操作 -</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="59"/>
+        <source>Trim</source>
+        <translation>修剪</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="64"/>
+        <source>Translate</source>
+        <translation>翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="69"/>
+        <source>Wrap</source>
+        <translation>换行</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="78"/>
+        <source>- Translation Column -</source>
+        <translation>- 翻译列 -</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="87"/>
+        <source>- Translation Endpoint -</source>
+        <translation>- 翻译接口 -</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="134"/>
+        <source>Leading &amp; Trailing</source>
+        <translation>前导和尾随</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="139"/>
+        <source>Leading</source>
+        <translation>前导</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="144"/>
+        <source>Trailing</source>
+        <translation>尾随</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="161"/>
+        <source>Wrap Length (20-255)</source>
+        <translation>换行长度（20-255）</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="207"/>
+        <source>Context</source>
+        <translation>上下文</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="238"/>
+        <source>Use File Context</source>
+        <translation>使用文件上下文</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="272"/>
+        <source>Process</source>
+        <translation>处理</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="70"/>
+        <source>Batch action not selected</source>
+        <translation>未选择批量操作</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="71"/>
+        <source>Select the batch action you want to perform.</source>
+        <translation>选择要执行的批量操作。</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="79"/>
+        <source>Translation column not selected</source>
+        <translation>未选择翻译列</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="80"/>
+        <source>Select the translation column you want perform the action in.</source>
+        <translation>选择要执行操作的翻译列。</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="99"/>
+        <source>Translation endpoint not selected</source>
+        <translation>未选择翻译接口</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="100"/>
+        <source>Select the translation endpoint you want to use.</source>
+        <translation>选择要使用的翻译接口。</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="109"/>
+        <source>Invalid value</source>
+        <translation>无效值</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="110"/>
+        <source>Wrap length input requires a number from 20 to 255.</source>
+        <translation>换行长度需要输入 20 到 255 之间的数字。</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="121"/>
+        <source>No files selected</source>
+        <translation>未选择文件</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="122"/>
+        <source>Select files you want to process in file select menu.</source>
+        <translation>在文件选择菜单中选择要处理的文件。</translation>
+    </message>
+</context>
+<context>
+    <name>BookmarkListDelegate</name>
+    <message>
+        <location filename="../src/BookmarkMenu/BookmarkList.cpp" line="158"/>
+        <source>Row %1 / File %2</source>
+        <translation>行 %1 / 文件 %2</translation>
+    </message>
+</context>
+<context>
+    <name>BookmarkMenu</name>
+    <message>
+        <location filename="../src/BookmarkMenu/BookmarkMenu.cpp" line="18"/>
+        <location filename="../src/BookmarkMenu/BookmarkMenu.cpp" line="117"/>
+        <source>- Filter by file -</source>
+        <translation>- 按文件筛选 -</translation>
+    </message>
+</context>
+<context>
+    <name>CBSLIWidget</name>
+    <message>
+        <location filename="../src/CBSLIWidget/CBSLIWidget.cpp" line="6"/>
+        <location filename="../src/CBSLIWidget/CBSLIWidget.cpp" line="50"/>
+        <source>Custom</source>
+        <translation>自定义</translation>
+    </message>
+</context>
+<context>
+    <name>FileSelectMenu</name>
+    <message>
+        <location filename="../src/FileSelectMenu/FileSelectMenu.ui" line="120"/>
+        <source>Select All</source>
+        <translation>全选</translation>
+    </message>
+    <message>
+        <location filename="../src/FileSelectMenu/FileSelectMenu.ui" line="127"/>
+        <source>Deselect All</source>
+        <translation>取消全选</translation>
+    </message>
+</context>
+<context>
+    <name>GlossaryMenu</name>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.ui" line="88"/>
+        <source>Search Input</source>
+        <translation>搜索输入</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="120"/>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.ui" line="186"/>
+        <source>Quality Check</source>
+        <translation>质量检查</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.ui" line="189"/>
+        <source>QC</source>
+        <translation>质检</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.ui" line="230"/>
+        <source>Term</source>
+        <translation>术语</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.ui" line="235"/>
+        <source>Translation</source>
+        <translation>翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.ui" line="240"/>
+        <source>Note</source>
+        <translation>备注</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.ui" line="245"/>
+        <source>Actions</source>
+        <translation>操作</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="121"/>
+        <source>No match found for: %1</source>
+        <translation>未找到匹配项：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="195"/>
+        <source>Term is empty</source>
+        <translation>术语为空</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="196"/>
+        <source>Empty term is not allowed.</source>
+        <translation>不允许空术语。</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="205"/>
+        <source>Translation is empty</source>
+        <translation>翻译为空</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="206"/>
+        <source>Empty term translation is not allowed.</source>
+        <translation>不允许空术语翻译。</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="225"/>
+        <source>Confirm Delete</source>
+        <translation>确认删除</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="226"/>
+        <source>Are you sure you want to delete this entry?</source>
+        <translation>确定要删除此条目吗？</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="125"/>
+        <source>Tab Panel</source>
+        <translation>标签面板</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="127"/>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="129"/>
+        <source>Write</source>
+        <translation>写入</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="131"/>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="134"/>
+        <source>Batch Menu</source>
+        <translation>批量菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="151"/>
+        <source>Bookmark Menu</source>
+        <translation>书签菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="138"/>
+        <source>Glossary Menu</source>
+        <translation>术语表菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="141"/>
+        <source>Match Menu</source>
+        <translation>匹配菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="146"/>
+        <source>Translations Menu</source>
+        <translation>翻译菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="155"/>
+        <source>Source Control</source>
+        <translation>源代码管理</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="157"/>
+        <source>Assets</source>
+        <translation>资源</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="160"/>
+        <source>Locate Project Directory</source>
+        <translation>定位项目目录</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="164"/>
+        <source>Search Panel</source>
+        <translation>搜索面板</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2256"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2268"/>
+        <source>Failed to open project</source>
+        <translation>打开项目失败</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1591"/>
+        <source>Open a project by using &apos;Open Folder&apos; button!</source>
+        <translation>使用"打开文件夹"按钮打开项目！</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1367"/>
+        <source>Select a game folder</source>
+        <translation>选择游戏文件夹</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="465"/>
+        <source>Read</source>
+        <translation>读取</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="466"/>
+        <source>Purge</source>
+        <translation>清除</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="276"/>
+        <source>Input line from %1 to %2</source>
+        <translation>输入行范围从 %1 到 %2</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="651"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="654"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="655"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2616"/>
+        <source>Translation</source>
+        <translation>翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3018"/>
+        <source>Failed to open tab: %1.</source>
+        <translation>打开标签页失败：%1。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3180"/>
+        <source>Tab %1 saved.</source>
+        <translation>标签页 %1 已保存。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3241"/>
+        <source>maps.txt saved.</source>
+        <translation>maps.txt 已保存。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3414"/>
+        <source>Matching failed</source>
+        <translation>匹配失败</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="339"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3695"/>
+        <source>No source files</source>
+        <translation>无源文件</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="147"/>
+        <source>Purging</source>
+        <translation>正在清除</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="149"/>
+        <source>Writing</source>
+        <translation>正在写入</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="151"/>
+        <source>Reading</source>
+        <translation>正在读取</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="340"/>
+        <source>Cannot write, source files are absent.</source>
+        <translation>无法写入，源文件不存在。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="372"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1515"/>
+        <source>Write failed</source>
+        <translation>写入失败</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="379"/>
+        <source>Written successfully</source>
+        <translation>写入成功</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="442"/>
+        <source>Libgit2 support is disabled</source>
+        <translation>Libgit2 支持已禁用</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="443"/>
+        <source>Program was compiled without support for libgit2, so it&apos;s impossible to access source control.</source>
+        <translation>程序编译时未启用 libgit2 支持，因此无法访问源代码管理。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1229"/>
+        <source>Set source and translation languages in Settings &gt; Project to show glossary matches.</source>
+        <translation>在 设置 &gt; 项目 中设置源语言和翻译语言以显示术语表匹配。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1233"/>
+        <source>Set source language in Settings &gt; Project to show glossary matches.</source>
+        <translation>在 设置 &gt; 项目 中设置源语言以显示术语表匹配。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1236"/>
+        <source>Set translation language in Settings &gt; Project to show glossary matches.</source>
+        <translation>在 设置 &gt; 项目 中设置翻译语言以显示术语表匹配。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1334"/>
+        <source>Set source and translation languages in Settings &gt; Project to show translations.</source>
+        <translation>在 设置 &gt; 项目 中设置源语言和翻译语言以显示翻译。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1338"/>
+        <source>Set source language in Settings &gt; Project to show translations.</source>
+        <translation>在 设置 &gt; 项目 中设置源语言以显示翻译。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1341"/>
+        <source>Set translation language in Settings &gt; Project to show translations.</source>
+        <translation>在 设置 &gt; 项目 中设置翻译语言以显示翻译。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1937"/>
+        <source>Cannot open settings window</source>
+        <translation>无法打开设置窗口</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1938"/>
+        <source>Settings can only be changed after opening a project.</source>
+        <translation>只有在打开项目后才能更改设置。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2037"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2113"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2220"/>
+        <source>Update failed</source>
+        <translation>更新失败</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2150"/>
+        <source>Up to date</source>
+        <translation>已是最新</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2151"/>
+        <source>Program is up-to-date.</source>
+        <translation>程序已是最新版本。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2161"/>
+        <source>Don&apos;t remind me</source>
+        <translation>不再提醒</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2162"/>
+        <source>New version is available</source>
+        <translation>有新版本可用</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2163"/>
+        <source>Version %1 is available.
+Current version is %2.</source>
+        <translation>版本 %1 可用。
+当前版本为 %2。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2166"/>
+        <source>Install</source>
+        <translation>安装</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2168"/>
+        <source>Skip</source>
+        <translation>跳过</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2178"/>
+        <source>Installing update...</source>
+        <translation>正在安装更新...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2179"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3524"/>
+        <source>Abort</source>
+        <translation>中止</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2221"/>
+        <source>Update failed with error: %1</source>
+        <translation>更新失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2236"/>
+        <source>%1 rows cut.</source>
+        <translation>已剪切 %1 行。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2239"/>
+        <source>%1 rows copied.</source>
+        <translation>已复制 %1 行。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2242"/>
+        <source>%1 rows pasted.</source>
+        <translation>已粘贴 %1 行。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2269"/>
+        <source>Failed to opened project because couldn&apos;t locate `.rpgmtranslate` program directory that was previously located at this path: %1. If this is intentional, please reopen the directory manually.</source>
+        <translation>打开项目失败，无法定位之前位于此路径的 `.rpgmtranslate` 程序目录：%1。如果这是有意为之，请手动重新打开目录。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2800"/>
+        <source>Existing translation folder</source>
+        <translation>现有翻译文件夹</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2801"/>
+        <source>Translation folder is found in the root of the project. Use it?</source>
+        <translation>在项目根目录中发现了翻译文件夹。是否使用？</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2910"/>
+        <source>Read was rejected by user.</source>
+        <translation>读取被用户拒绝。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="380"/>
+        <source>Elapsed: %1s.</source>
+        <translation>耗时：%1秒。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="624"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3046"/>
+        <source>%1 Translated / %2 Total</source>
+        <translation>%1 已翻译 / %2 总计</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="707"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3037"/>
+        <source>%1 Lines / %2 Comments</source>
+        <translation>%1 行 / %2 条评论</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="768"/>
+        <source>Source language is not set</source>
+        <translation>未设置源语言</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="769"/>
+        <source>Cannot perform batch-translate. You need to set source language in Settings &gt; Project first.</source>
+        <translation>无法执行批量翻译。需要先在 设置 &gt; 项目 中设置源语言。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="779"/>
+        <source>Translation language is not set</source>
+        <translation>未设置翻译语言</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="780"/>
+        <source>Cannot perform batch-translate. You need to set translation language in Settings &gt; Project first.</source>
+        <translation>无法执行批量翻译。需要先在 设置 &gt; 项目 中设置翻译语言。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="814"/>
+        <source>Batch translation failed</source>
+        <translation>批量翻译失败</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="815"/>
+        <source>Batch translation failed with error: %1</source>
+        <translation>批量翻译失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1059"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1135"/>
+        <source>Files were skipped</source>
+        <translation>文件被跳过</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1060"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1136"/>
+        <source>The program was unable to open the following files:
+ %1</source>
+        <translation>程序无法打开以下文件：
+ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1416"/>
+        <source>Read failed</source>
+        <translation>读取失败</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1478"/>
+        <source>Purge failed</source>
+        <translation>清除失败</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1479"/>
+        <source>Purge failed with error: %1</source>
+        <translation>清除失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1516"/>
+        <source>Write failed with error: %1</source>
+        <translation>写入失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1524"/>
+        <source>Write finished</source>
+        <translation>写入完成</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1525"/>
+        <source>Elapsed: %1</source>
+        <translation>耗时：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2038"/>
+        <source>Failed to open update archive</source>
+        <translation>打开更新压缩包失败</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2114"/>
+        <source>Failed to extract update archive</source>
+        <translation>解压更新压缩包失败</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2257"/>
+        <source>Folder %1 does not exist.</source>
+        <translation>文件夹 %1 不存在。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2696"/>
+        <source>Baseline couldn&apos;t be found</source>
+        <translation>找不到基线</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2697"/>
+        <source>Copying the data directory to .rpgmtranslate/baseline-data as a baseline.</source>
+        <translation>正在将数据目录复制到 .rpgmtranslate/baseline-data 作为基线。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2889"/>
+        <source>Source files, translation or archive file do not exist.</source>
+        <translation>源文件、翻译或压缩文件不存在。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3563"/>
+        <source>Search finished.</source>
+        <translation>搜索完成。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3563"/>
+        <source>Searching...</source>
+        <translation>正在搜索...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3568"/>
+        <source>Replace finished.</source>
+        <translation>替换完成。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3568"/>
+        <source>Replacing...</source>
+        <translation>正在替换...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3573"/>
+        <source>Put finished.</source>
+        <translation>放入完成。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3573"/>
+        <source>Putting...</source>
+        <translation>正在放入...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3578"/>
+        <source>Trim finished.</source>
+        <translation>修剪完成。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3578"/>
+        <source>Trimming...</source>
+        <translation>正在修剪...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3583"/>
+        <source>Sending translation request...</source>
+        <translation>正在发送翻译请求...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3588"/>
+        <source>Translate finished.</source>
+        <translation>翻译完成。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3588"/>
+        <source>Translating...</source>
+        <translation>正在翻译...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3593"/>
+        <source>Wrap finished.</source>
+        <translation>换行完成。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3593"/>
+        <source>Wrapping...</source>
+        <translation>正在换行...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3614"/>
+        <source>Source path does not exist</source>
+        <translation>源路径不存在</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3615"/>
+        <source>The source path %1 does not exist.</source>
+        <translation>源路径 %1 不存在。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3696"/>
+        <source>No matching source files were found in:
+%1</source>
+        <translation>在以下位置未找到匹配的源文件：
+%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3705"/>
+        <source>
+
+Skipped files:
+%1</source>
+        <translation>
+
+跳过的文件：
+%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3740"/>
+        <source>Changed files: [%1]</source>
+        <translation>已更改的文件：[%1]</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3747"/>
+        <source>New files: [%1]</source>
+        <translation>新文件：[%1]</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3752"/>
+        <source>Source files have been updated</source>
+        <translation>源文件已更新</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3753"/>
+        <source>%1
+
+The files have been changed. Do you want to append any new text?%2</source>
+        <translation>%1
+
+文件已更改。是否要追加新文本？%2</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3764"/>
+        <source>Project up-to-date</source>
+        <translation>项目已是最新</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3765"/>
+        <source>All source files are up-to-date.%1</source>
+        <translation>所有源文件都是最新的。%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="363"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1407"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1469"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1506"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2747"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3491"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3600"/>
+        <source>No Tasks</source>
+        <translation>无任务</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1696"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1746"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1798"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1845"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3017"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3104"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3208"/>
+        <source>Failed to open file</source>
+        <translation>打开文件失败</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1697"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1747"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1799"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="1846"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3105"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3209"/>
+        <source>Failed to open file %1: %2. Starting from the beginning.</source>
+        <translation>打开文件 %1 失败：%2。从头开始。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2570"/>
+        <source>%1: Successfully parsed.</source>
+        <translation>%1：解析成功。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3506"/>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3507"/>
+        <source>Saving file failed</source>
+        <translation>保存文件失败</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3509"/>
+        <source>Unable to save file %1: %2. You may try to save the file to a custom location. It&apos;s strongly advised to you to better close the program and fix the underlying issue before continuing your work.</source>
+        <translation>无法保存文件 %1：%2。您可以尝试将文件保存到自定义位置。强烈建议您在继续工作之前关闭程序并修复潜在问题。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3516"/>
+        <source>Continue anyway</source>
+        <translation>仍然继续</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3518"/>
+        <source>Retry</source>
+        <translation>重试</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3520"/>
+        <source>Save to custom location</source>
+        <translation>保存到自定义位置</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2609"/>
+        <source>Source</source>
+        <translation>源文</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2677"/>
+        <source>Before working with the program, check out documentation in Help &gt; Documentation!</source>
+        <translation>在使用程序之前，请查看 帮助 &gt; 使用文档！</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2741"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2923"/>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="2968"/>
+        <source>Failed to load project</source>
+        <translation>加载项目失败</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3004"/>
+        <source>File is unavailable</source>
+        <translation>文件不可用</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3005"/>
+        <source>File is currently processed and is being locked.</source>
+        <translation>文件正在处理中，已被锁定。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="3380"/>
+        <source>Backup %1 created.</source>
+        <translation>备份 %1 已创建。</translation>
+    </message>
+</context>
+<context>
+    <name>MatchTable</name>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="319"/>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="337"/>
+        <source>Exact</source>
+        <translation>精确</translation>
+    </message>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="322"/>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="340"/>
+        <source>Fuzzy (%1)</source>
+        <translation>模糊（%1）</translation>
+    </message>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="347"/>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="355"/>
+        <source>%1, %2 occurrences: %3</source>
+        <translation>%1，%2 次出现：%3</translation>
+    </message>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="366"/>
+        <source>Translation is empty.</source>
+        <translation>翻译为空。</translation>
+    </message>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="368"/>
+        <source>Term translation is not present.</source>
+        <term translation is not present.</source>
+        <translation>术语翻译不存在。</translation>
+    </message>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="370"/>
+        <source>Number of term occurrences doesn&apos;t match the number of translation occurrences.</source>
+        <translation>术语出现次数与翻译出现次数不匹配。</translation>
+    </message>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="374"/>
+        <source>Match.</source>
+        <translation>匹配。</translation>
+    </message>
+</context>
+<context>
+    <name>MatchTableModel</name>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="189"/>
+        <source>Filename</source>
+        <translation>文件名</translation>
+    </message>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="191"/>
+        <source>Line</source>
+        <translation>行</translation>
+    </message>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="193"/>
+        <source>Term</source>
+        <translation>术语</translation>
+    </message>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="195"/>
+        <source>Translation</source>
+        <translation>翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="197"/>
+        <source>Source match</source>
+        <translation>源文匹配</translation>
+    </message>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="199"/>
+        <source>Translation match</source>
+        <translation>翻译匹配</translation>
+    </message>
+    <message>
+        <location filename="../src/MatchMenu/MatchTable.cpp" line="201"/>
+        <source>Info</source>
+        <translation>信息</translation>
+    </message>
+</context>
+<context>
+    <name>MediaPlayer</name>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="352"/>
+        <source>Resume</source>
+        <translation>继续</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="352"/>
+        <source>Pause</source>
+        <translation>暂停</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="417"/>
+        <source>Done</source>
+        <translation>完成</translation>
+    </message>
+</context>
+<context>
+    <name>PurgeMenu</name>
+    <message>
+        <location filename="../src/PurgeMenu/PurgeMenu.ui" line="60"/>
+        <source>Create .rvpacker-ignore file from purged lines to prevent their further appearance.</source>
+        <translation>从已清除的行创建 .rvpacker-ignore 文件，以防止它们再次出现。</translation>
+    </message>
+    <message>
+        <location filename="../src/PurgeMenu/PurgeMenu.ui" line="91"/>
+        <source>Close</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <location filename="../src/PurgeMenu/PurgeMenu.ui" line="98"/>
+        <source>Apply</source>
+        <translation>应用</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/utilities/Utils.cpp" line="14"/>
+        <source>Couldn&apos;t split text at line %1 in file %2</source>
+        <translation>无法在文件 %2 的第 %1 行分割文本</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="297"/>
+        <source>Pause</source>
+        <translation>暂停</translation>
+    </message>
+</context>
+<context>
+    <name>ReadMenu</name>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="77"/>
+        <source>Read Mode</source>
+        <translation>读取模式</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="94"/>
+        <source>Default</source>
+        <translation>默认</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="99"/>
+        <source>Force</source>
+        <translation>强制</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="104"/>
+        <source>Append</source>
+        <translation>追加</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="109"/>
+        <source>Force Append</source>
+        <translation>强制追加</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="120"/>
+        <source>Default mode does nothing, when the source files are unchanged since the last read - in this case use force append mode.</source>
+        <translation>默认模式下，如果源文件自上次读取以来未更改，则不执行任何操作——在这种情况下请使用强制追加模式。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="175"/>
+        <source>Duplicate Mode</source>
+        <translation>重复模式</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="194"/>
+        <source>Remove Duplicates</source>
+        <translation>移除重复</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="189"/>
+        <source>Allow Duplicates</source>
+        <translation>允许重复</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="205"/>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="132"/>
+        <source>Remove duplicates across maps and events. Recommended. In system, scripts and plugins files this mode is always overridden by allow mode.</source>
+        <translation>跨地图和事件移除重复。推荐。在系统、脚本和插件文件中，此模式始终被允许模式覆盖。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="255"/>
+        <source>Romanize: When parsing text from a Japanese game, that contains symbols like 「」, which are just the Japanese quotation marks, it automatically replaces these symbols by their western equivalents (in this case, &apos;&apos;).</source>
+        <translation>罗马化：在解析包含「」等符号（即日语引号）的日文游戏文本时，自动将其替换为对应的西文符号（在本例中为 ''）。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="305"/>
+        <source>Trim: Removes the leading and trailing whitespace from extracted strings. Don&apos;t use this option unless you know that trimming the text won&apos;t cause any incorrect behavior.</source>
+        <translation>修剪：从提取的字符串中移除前导和尾随空格。除非您确定修剪文本不会导致任何错误行为，否则请勿使用此选项。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="355"/>
+        <source>Disable Custom Processing: Disables built-in custom processing, implemented for some games. Right now, implemented for the following titles: LISA: The Painful and its derivatives, Fear &amp; Hunger 2: Termina.</source>
+        <translation>禁用自定义处理：禁用为某些游戏实现的自定义处理。目前适用于以下游戏：LISA: The Painful 及其衍生作品、Fear &amp; Hunger 2: Termina。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="408"/>
+        <source>Ignore: Ignore entries from .rvpacker-ignore file.</source>
+        <translation>忽略：忽略 .rvpacker-ignore 文件中的条目。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="461"/>
+        <source>Skip Obsolete: Don&apos;t preserve obsolete entries from the previous read.</source>
+        <translation>跳过过时条目：不保留上次读取中的过时条目。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="508"/>
+        <source>Parse Map Events: Parses map events metadata, such as event ID, name, x/y position.</source>
+        <translation>解析地图事件：解析地图事件元数据，如事件 ID、名称、x/y 坐标。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="552"/>
+        <source>Use title from Game.ini: If game is RPG Maker XP/VX/VX Ace, it may not necessarily contain game title in the system file. Use this option to take it from Game.ini. You will have to pick the right encoding. If this option is not set, we&apos;ll try to use the title from system file, if it&apos;s there.</source>
+        <translation>使用 Game.ini 中的标题：如果游戏是 RPG Maker XP/VX/VX Ace，系统文件中可能不包含游戏标题。使用此选项可从 Game.ini 中获取标题。您需要选择正确的编码。如果未设置此选项，我们将尝试使用系统文件中的标题（如果存在）。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="575"/>
+        <source>UTF-8</source>
+        <translation>UTF-8</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="580"/>
+        <source>Shift_JIS</source>
+        <translation>Shift_JIS</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="585"/>
+        <source>GB18030</source>
+        <translation>GB18030</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="624"/>
+        <source>Close</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="631"/>
+        <source>Apply</source>
+        <translation>应用</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="49"/>
+        <source>Force rewrites existing translation files.</source>
+        <translation>强制重写现有翻译文件。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="63"/>
+        <source>Appends any new text from the game to the translation files, if the text is not already present. Lines order is sorted, unused lines go to the bottom of the map/event. Default mode does nothing, when the source files are unchanged since the last read - in this case use force append mode.</source>
+        <translation>将游戏中的新文本追加到翻译文件中（如果文本尚不存在）。行顺序已排序，未使用的行将移至地图/事件的底部。默认模式下，如果源文件自上次读取以来未更改，则不执行任何操作——在这种情况下请使用强制追加模式。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="89"/>
+        <source>Appends any new text from the game to the translation files, if the text is not already present. Lines order is sorted, unused lines go to the bottom of the map/event.</source>
+        <translation>将游戏中的新文本追加到翻译文件中（如果文本尚不存在）。行顺序已排序，未使用的行将移至地图/事件的底部。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="35"/>
+        <source>Invalid mode</source>
+        <translation>无效模式</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="36"/>
+        <source>Default mode does nothing when files are already read.</source>
+        <translation>文件已读取时，默认模式不执行任何操作。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="45"/>
+        <source>Parses the game text.</source>
+        <translation>解析游戏文本。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="127"/>
+        <source>Allow duplicates across maps and events. This may bloat your translation. This mode is always set for system, scripts, and plugins files.</source>
+        <translation>允许跨地图和事件重复。这可能会使翻译文件膨胀。系统、脚本和插件文件始终使用此模式。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="159"/>
+        <source>Failed to extract INI title</source>
+        <translation>提取 INI 标题失败</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="160"/>
+        <source>Failed to extract title from the Game.ini file: %1</source>
+        <translation>从 Game.ini 文件提取标题失败：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="170"/>
+        <source>Title is empty</source>
+        <translation>标题为空</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="171"/>
+        <source>Title is empty in Game.ini file.</source>
+        <translation>Game.ini 文件中标题为空。</translation>
+    </message>
+</context>
+<context>
+    <name>SearchMenu</name>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="47"/>
+        <source>Search input</source>
+        <translation>搜索输入</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="102"/>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="140"/>
+        <source>Replace</source>
+        <translation>替换</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="178"/>
+        <source>Put</source>
+        <translation>放入</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="216"/>
+        <source>Replace input</source>
+        <translation>替换输入</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="265"/>
+        <source>Match Case</source>
+        <translation>区分大小写</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="306"/>
+        <source>Search Whole</source>
+        <translation>全词搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="347"/>
+        <source>Search By Regular Expression</source>
+        <translation>正则表达式搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="388"/>
+        <source>Search In Comments</source>
+        <translation>在评论中搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="429"/>
+        <source>Files To Search</source>
+        <translation>搜索范围</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="480"/>
+        <source>Search Everywhere</source>
+        <translation>搜索全部</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="485"/>
+        <source>Only Source</source>
+        <translation>仅源文</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="490"/>
+        <source>Only Translation</source>
+        <translation>仅翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="499"/>
+        <source>All Columns</source>
+        <translation>所有列</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="504"/>
+        <source>Rightmost Column</source>
+        <translation>最右列</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="13"/>
+        <source>No files selected</source>
+        <translation>未选择文件</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="14"/>
+        <source>Select some files to process in file select menu.</source>
+        <translation>在文件选择菜单中选择要处理的文件。</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="33"/>
+        <source>No search text</source>
+        <translation>无搜索文本</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="34"/>
+        <source>Search input is empty.</source>
+        <translation>搜索输入为空。</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="47"/>
+        <source>Replace input is empty</source>
+        <translation>替换输入为空</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="48"/>
+        <source>Do you really want to replace the text to nothing?</source>
+        <translation>确定要将文本替换为空吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="22"/>
+        <source>Invalid column for replace</source>
+        <translation>替换的列无效</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="23"/>
+        <source>Replace can only be performed in a certain column.</source>
+        <translation>替换只能在特定列中执行。</translation>
+    </message>
+</context>
+<context>
+    <name>SearchPanelDock</name>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="227"/>
+        <source>Already replaced</source>
+        <translation>已替换</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="228"/>
+        <source>This result was already replaced.</source>
+        <translation>此结果已被替换。</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="195"/>
+        <source>Confirmation</source>
+        <translation>确认</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="86"/>
+        <source>File %1 / Row %2 / Column %3 (%4)</source>
+        <translation>文件 %1 / 行 %2 / 列 %3（%4）</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="92"/>
+        <source>Source</source>
+        <translation>源文</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="196"/>
+        <source>Do you really want to put the text from the replace input in place of this text, effectively replacing it?</source>
+        <translation>确定要用替换输入中的文本替换此文本吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="220"/>
+        <source>Cannot be replaced</source>
+        <translation>无法替换</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="221"/>
+        <source>Source column cannot be replaced.</source>
+        <translation>源文列无法替换。</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="112"/>
+        <source>- Filter by file -</source>
+        <translation>- 按文件筛选 -</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="32"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1915"/>
+        <source>Settings</source>
+        <translation>设置</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="142"/>
+        <source>Core</source>
+        <translation>核心</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="143"/>
+        <source>Appearance</source>
+        <translation>外观</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="144"/>
+        <source>Controls</source>
+        <translation>快捷键</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="145"/>
+        <source>Translation</source>
+        <translation>翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="146"/>
+        <source>Project</source>
+        <translation>项目</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="163"/>
+        <source>Backup</source>
+        <translation>备份</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="204"/>
+        <source>In seconds. Range from 60 to 3600</source>
+        <translation>以秒为单位。范围 60 到 3600</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="245"/>
+        <source>Range from 10 to 1000</source>
+        <translation>范围 10 到 1000</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="258"/>
+        <source>Check for updates</source>
+        <translation>检查更新</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="194"/>
+        <source>Backup period</source>
+        <translation>备份周期</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="238"/>
+        <source>Max backups</source>
+        <translation>最大备份数</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="345"/>
+        <source>Translation table font</source>
+        <translation>翻译表字体</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="430"/>
+        <source>Style</source>
+        <translation>样式</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="467"/>
+        <source>Theme</source>
+        <translation>主题</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="475"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1320"/>
+        <source>Default</source>
+        <translation>默认</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="480"/>
+        <source>Light</source>
+        <translation>浅色</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="485"/>
+        <source>Dark</source>
+        <translation>深色</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="549"/>
+        <source>Search Panel</source>
+        <translation>搜索面板</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="704"/>
+        <source>Match Menu</source>
+        <translation>匹配菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="735"/>
+        <source>Glossary Menu</source>
+        <translation>术语表菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1094"/>
+        <source>Type</source>
+        <translation>类型</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1102"/>
+        <source>Google</source>
+        <translation>Google</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1107"/>
+        <source>Yandex</source>
+        <translation>Yandex</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1112"/>
+        <source>DeepL</source>
+        <translation>DeepL</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1117"/>
+        <source>Aliyun</source>
+        <translation>阿里云</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1122"/>
+        <source>Anthropic</source>
+        <translation>Anthropic</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1127"/>
+        <source>DeepSeek</source>
+        <translation>DeepSeek</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1132"/>
+        <source>Gemini</source>
+        <translation>Gemini</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1137"/>
+        <source>Koboldcpp</source>
+        <translation>Koboldcpp</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1142"/>
+        <source>Longcat</source>
+        <translation>Longcat</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1147"/>
+        <source>Moonshot</source>
+        <translation>Moonshot</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1152"/>
+        <source>Mistral</source>
+        <translation>Mistral</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1157"/>
+        <source>Ollama</source>
+        <translation>Ollama</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1162"/>
+        <source>OpenAI</source>
+        <translation>OpenAI</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1167"/>
+        <source>OpenAI-compatible</source>
+        <translation>OpenAI 兼容</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1172"/>
+        <source>Volcengine</source>
+        <translation>火山引擎</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1177"/>
+        <source>Xiaomi</source>
+        <translation>小米</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1182"/>
+        <source>Xinference</source>
+        <translation>Xinference</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1187"/>
+        <source>Zhipu</source>
+        <translation>智谱</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1208"/>
+        <source>Use for single translation (will display text translation through the endpoint in translations menu)</source>
+        <translation>用于单条翻译（将在翻译菜单中通过接口显示文本翻译）</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1233"/>
+        <source>API key</source>
+        <translation>API 密钥</translation>
+    </message>
+    <message>
+               <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1268"/>
+        <source>Yandex folder ID</source>
+        <translation>Yandex 文件夹 ID</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1330"/>
+        <source>If &quot;Check key&quot; outputs something about incorrect URL, missing page etc., make sure that your base URL includes the API version. For example: &quot;https://api.openai.com/v1&quot; or &quot;https://generativelanguage.googleapis.com/v1beta&quot;. Don&apos;t include parts like &quot;/chat/completions&quot; in the URL!</source>
+        <translation>如果"检查密钥"输出了关于错误 URL、页面缺失等信息，请确保您的基础 URL 包含 API 版本。例如："https://api.openai.com/v1" 或 "https://generativelanguage.googleapis.com/v1beta"。不要在 URL 中包含 "/chat/completions" 等部分！</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1340"/>
+        <source>Check key</source>
+        <translation>检查密钥</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1430"/>
+        <source>Reasoning effort</source>
+        <translation>推理力度</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1438"/>
+        <source>Low</source>
+        <translation>低</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1443"/>
+        <source>Medium</source>
+        <translation>中</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1448"/>
+        <source>High</source>
+        <translation>高</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1459"/>
+        <source>Thinking/reasoning</source>
+        <translation>思考/推理</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1466"/>
+        <source>Use glossary</source>
+        <translation>使用术语表</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1642"/>
+        <source>LanguageTool base URL</source>
+        <translation>LanguageTool 基础 URL</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1662"/>
+        <source>Yanfly Engine Core Lints</source>
+        <translation>Yanfly Engine Core 检查</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1683"/>
+        <source>Yanfly Core Engine</source>
+        <translation>Yanfly Core Engine</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1710"/>
+        <source>Advanced Text System Lints</source>
+        <translation>高级文本系统检查</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1734"/>
+        <source>Custom Lints</source>
+        <translation>自定义检查</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1758"/>
+        <source>Misc</source>
+        <translation>杂项</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1831"/>
+        <source>Highlight leading whitespace</source>
+        <translation>高亮前导空格</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1838"/>
+        <source>Highlight trailing whitespace</source>
+        <translation>高亮尾随空格</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1845"/>
+        <source>Highlight contiguous whitespace</source>
+        <translation>高亮连续空格</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1852"/>
+        <source>Highlight unclosed punctuation</source>
+        <translation>高亮未闭合标点</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1859"/>
+        <source>Display source/translation tag mismatch</source>
+        <translation>显示源文/翻译标签不匹配</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1866"/>
+        <source>Display words/characters count for a file</source>
+        <translation>显示文件的字数/字符数</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1957"/>
+        <source>Line length hint</source>
+        <translation>行长度提示</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1983"/>
+        <source>Source language</source>
+        <translation>源语言</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1999"/>
+        <source>Translation language</source>
+        <translation>翻译语言</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2009"/>
+        <source>Spellcheck dictionary</source>
+        <translation>拼写检查词典</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2031"/>
+        <source>Context</source>
+        <translation>上下文</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2070"/>
+        <source>File context select</source>
+        <translation>文件上下文选择</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2101"/>
+        <source>File context</source>
+        <translation>文件上下文</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2132"/>
+        <source>Project сontext</source>
+        <translation>项目上下文</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="580"/>
+        <source>Tab Panel</source>
+        <translation>标签面板</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="611"/>
+        <source>Go To Row</source>
+        <translation>跳转到行</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="642"/>
+        <source>Batch Menu</source>
+        <translation>批量菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="673"/>
+        <source>Bookmark Menu</source>
+        <translation>书签菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="766"/>
+        <source>Translations Menu</source>
+        <translation>翻译菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="871"/>
+        <source>Machine Translation</source>
+        <translation>机器翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="919"/>
+        <source>Endpoint List</source>
+        <translation>接口列表</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="969"/>
+        <source>Select endpoints by clicking on them. You can change the name by double-clicking an endpoint.</source>
+        <translation>点击选择接口。双击接口可修改名称。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="994"/>
+        <source>Add Endpoint</source>
+        <translation>添加接口</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1032"/>
+        <source>Remove Selected Endpoint</source>
+        <translation>移除所选接口</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1303"/>
+        <source>Base URL</source>
+        <translation>基础 URL</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1310"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1649"/>
+        <source>https://localhost:8000</source>
+        <translation>https://localhost:8000</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1371"/>
+        <source>Model</source>
+        <translation>模型</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="107"/>
+        <source>Temperature</source>
+        <translation>温度</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1491"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1504"/>
+        <source>System Prompt</source>
+        <translation>系统提示词</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1511"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1559"/>
+        <source>Default System Prompt</source>
+        <translation>默认系统提示词</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1539"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1552"/>
+        <source>Single Translate System Prompt</source>
+        <translation>单条翻译系统提示词</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1596"/>
+        <source>LanguageTool</source>
+        <translation>LanguageTool</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1617"/>
+        <source>Use LanguageTool linting</source>
+        <translation>使用 LanguageTool 检查</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1797"/>
+        <source>Symbols that should be considered space (comma-separated list; literal symbols and Unicode U+XXXX codepoints are allowed):</source>
+        <translation>应视为空格的符号（逗号分隔列表；允许字面符号和 Unicode U+XXXX 码点）：</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1970"/>
+        <source>In characters. Allowed range: 0-255.</source>
+        <translation>以字符为单位。允许范围：0-255。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="104"/>
+        <source>Thinking budget limit</source>
+        <translation>思考预算限制</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="109"/>
+        <source>Frequency penalty</source>
+        <translation>频率惩罚</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="111"/>
+        <source>Precense penalty</source>
+        <translation>存在惩罚</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="113"/>
+        <source>Top P</source>
+        <translation>Top P</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="117"/>
+        <source>Translation table font size</source>
+        <translation>翻译表字体大小</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="164"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="170"/>
+        <source>Endpoint %1</source>
+        <translation>接口 %1</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="228"/>
+        <source>Google Translate. Free and unlimited. Configured options don&apos;t work with this endpoint.</source>
+        <translation>Google 翻译。免费且无限制。配置的选项不适用于此接口。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="233"/>
+        <source>Yandex Translate. Requires API key and folder ID. Configured options don&apos;t work with this endpoint.</source>
+        <translation>Yandex 翻译。需要 API 密钥和文件夹 ID。配置的选项不适用于此接口。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="238"/>
+        <source>DeepL. Requires API key and folder ID. Configured options don&apos;t work with this endpoint, except glossary usage.</source>
+        <translation>DeepL。需要 API 密钥和文件夹 ID。除术语表使用外，配置的选项不适用于此接口。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="246"/>
+        <source>LLM endpoint with pre-defined base URL. Don&apos;t change the base URL, unless you know what you&apos;re doing. Configured options will affect this endpoint.</source>
+        <translation>具有预定义基础 URL 的 LLM 接口。除非您知道自己在做什么，否则不要更改基础 URL。配置的选项将影响此接口。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="251"/>
+        <source>OpenAI-compatible endpoint. This category fits many providers, including OpenAI itself, DeepSeek, Mistral, and local providers, such as llama.cpp and koboldcpp. Requires valid base URL, that should probably end with &apos;/v1&apos;. Configured options will affect this endpoint.</source>
+        <translation>OpenAI 兼容接口。此类别适用于许多提供商，包括 OpenAI 本身、DeepSeek、Mistral 以及本地提供商（如 llama.cpp 和 koboldcpp）。需要有效的基础 URL，应以 "/v1" 结尾。配置的选项将影响此接口。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="370"/>
+        <source>Couldn&apos;t select model</source>
+        <translation>无法选择模型</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="371"/>
+        <source>Model that was previously selected for translation: %1 is not longer in the list of models provided by the endpoint.</source>
+        <translation>之前为翻译选择的模型：%1 已不在接口提供的模型列表中。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="448"/>
+        <source>URL is invalid</source>
+        <translation>URL 无效</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="449"/>
+        <source>Given URL is invalid. Please check the validity of submitted URL.</source>
+        <translation>给定的 URL 无效。请检查提交的 URL 的有效性。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="855"/>
+        <source>Failed to validate key</source>
+        <translation>验证密钥失败</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="856"/>
+        <source>Getting available models failed with error: %1</source>
+        <translation>获取可用模型失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="481"/>
+        <source>No .dic file</source>
+        <translation>无 .dic 文件</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="482"/>
+        <source>`.dic` file corresponding to the `.aff` file does not exist. Dictionary won&apos;t work properly without the `.dic` file.</source>
+        <translation>与 `.aff` 文件对应的 `.dic` 文件不存在。没有 `.dic` 文件，词典将无法正常工作。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="640"/>
+        <source>Invalid backup period</source>
+        <translation>无效的备份周期</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="641"/>
+        <source>Backup period is invalid. Unable to save.</source>
+        <translation>备份周期无效。无法保存。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="651"/>
+        <source>Invalid max backups</source>
+        <translation>无效的最大备份数</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="652"/>
+        <source>Max backups value is invalid. Unable to save.</source>
+        <translation>最大备份数值无效。无法保存。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="716"/>
+        <source>Invalid line length hint</source>
+        <translation>无效的行长度提示</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="717"/>
+        <source>Line length hint is invalid. Unable to save.</source>
+        <translation>行长度提示无效。无法保存。</translation>
+    </message>
+</context>
+<context>
+    <name>SourceControlDock</name>
+    <message>
+        <location filename="../src/SourceControlDock/SourceControlDock.cpp" line="73"/>
+        <source>Commit (Amend)</source>
+        <translation>提交（修订）</translation>
+    </message>
+    <message>
+        <location filename="../src/SourceControlDock/SourceControlDock.cpp" line="75"/>
+        <source>Commit and push</source>
+        <translation>提交并推送</translation>
+    </message>
+</context>
+<context>
+    <name>TabPanel</name>
+    <message>
+        <location filename="../src/TabPanel/TabPanel.cpp" line="51"/>
+        <source>Unmark Completed</source>
+        <translation>取消完成标记</translation>
+    </message>
+    <message>
+        <location filename="../src/TabPanel/TabPanel.cpp" line="51"/>
+        <source>Mark as Completed</source>
+        <translation>标记为已完成</translation>
+    </message>
+    <message>
+        <location filename="../src/TabPanel/TabPanel.cpp" line="57"/>
+        <source>Toggle Progress Display</source>
+        <translation>切换进度显示</translation>
+    </message>
+</context>
+<context>
+    <name>TaskWorker</name>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="469"/>
+        <source>Files were skipped</source>
+        <translation>文件被跳过</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="470"/>
+        <source>The program was unable to open the following files:
+ %1</source>
+        <translation>程序无法打开以下文件：
+ %1</translation>
+    </message>
+</context>
+<context>
+    <name>TermInfoCell</name>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="433"/>
+        <source>Exact</source>
+        <translation>精确</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="434"/>
+        <source>Fuzzy</source>
+        <translation>模糊</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="435"/>
+        <source>Both</source>
+        <translation>两者</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="438"/>
+        <source>Case Sensitive</source>
+        <translation>区分大小写</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="439"/>
+        <source>Permissive</source>
+        <translation>宽松</translation>
+    </message>
+</context>
+<context>
+    <name>TextCodes</name>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="39"/>
+        <source>ATS Message Options: \nb{text} - Shows the namebox with text displayed.</source>
+        <translation>ATS 消息选项：\nb{text} - 显示带文本的名称框。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="42"/>
+        <source>ATS Message Options: \nbl{text} - Shows the namebox left of the message with text displayed.</source>
+        <translation>ATS 消息选项：\nbl{text} - 在消息左侧显示带文本的名称框。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="45"/>
+        <source>ATS Message Options: \nbr{text} - Shows the namebox right of the message with text displayed.</source>
+        <translation>ATS 消息选项：\nbr{text} - 在消息右侧显示带文本的名称框。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="48"/>
+        <source>ATS Message Options: \nbt{text} - Shows the namebox above the message with text displayed.</source>
+        <translation>ATS 消息选项：\nbt{text} - 在消息上方显示带文本的名称框。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="51"/>
+        <source>ATS Message Options: \nbb{text} - Shows the namebox below the message with text displayed.</source>
+        <translation>ATS 消息选项：\nbb{text} - 在消息下方显示带文本的名称框。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="54"/>
+        <source>ATS Message Options: \nblt{text} - Shows the namebox left and above with text displayed.</source>
+        <translation>ATS 消息选项：\nblt{text} - 在左上方显示带文本的名称框。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="57"/>
+        <source>ATS Message Options: \nblb{text} - Shows the namebox left and below with text displayed.</source>
+        <translation>ATS 消息选项：\nblb{text} - 在左下方显示带文本的名称框。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="60"/>
+        <source>ATS Message Options: \nbrt{text} - Shows the namebox right and above with text displayed.</source>
+        <translation>ATS 消息选项：\nbrt{text} - 在右上方显示带文本的名称框。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="63"/>
+        <source>ATS Message Options: \nbrb{text} - Shows the namebox right and below with text displayed.</source>
+        <translation>ATS 消息选项：\nbrb{text} - 在右下方显示带文本的名称框。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="66"/>
+        <source>ATS Message Options: \fit - Fits the window to this message (:paragraph_format must be false).</source>
+        <translation>ATS 消息选项：\fit - 将窗口适配到此消息（:paragraph_format 必须为 false）。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="69"/>
+        <source>ATS Message Options: \e[n] - Sets the text box in reference to character n (0 = Player; &gt;0 = Event).</source>
+        <translation>ATS 消息选项：\e[n] - 根据角色 n 设置文本框（0 = 玩家；&gt;0 = 事件）。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="72"/>
+        <source>ATS Message Options: \et[n] - Sets the text box above character n (0 = Player; &gt;0 = Event).</source>
+        <translation>ATS 消息选项：\et[n] - 将文本框设置在角色 n 上方（0 = 玩家；&gt;0 = 事件）。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="75"/>
+        <source>ATS Message Options: \eb[n] - Sets the text box below character n (0 = Player; &gt;0 = Event).</source>
+        <translation>ATS 消息选项：\eb[n] - 将文本框设置在角色 n 下方（0 = 玩家；&gt;0 = 事件）。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="78"/>
+        <source>ATS Message Options: \el[n] - Sets the text box to the left of character n (0 = Player; &gt;0 = Event).</source>
+        <translation>ATS 消息选项：\el[n] - 将文本框设置在角色 n 左侧（0 = 玩家；&gt;0 = 事件）。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="81"/>
+        <source>ATS Message Options: \er[n] - Sets the text box to the right of character n (0 = Player; &gt;0 = Event).</source>
+        <translation>ATS 消息选项：\er[n] - 将文本框设置在角色 n 右侧（0 = 玩家；&gt;0 = 事件）。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="84"/>
+        <source>ATS Message Options: \lse - Turns the letter by letter SE on.</source>
+        <translation>ATS 消息选项：\lse - 开启逐字音效。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="87"/>
+        <source>ATS Message Options: /lse - Turns the letter by letter SE off.</source>
+        <translation>ATS 消息选项：/lse - 关闭逐字音效。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="90"/>
+        <source>ATS Message Options: \pse - Turns the pause SE on.</source>
+        <translation>ATS 消息选项：\pse - 开启暂停音效。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="91"/>
+        <source>ATS Message Options: /pse - Turns the pause SE off.</source>
+        <translation>ATS 消息选项：/pse - 关闭暂停音效。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="92"/>
+        <source>ATS Message Options: \fse - Turns the finish SE on.</source>
+        <translation>ATS 消息选项：\fse - 开启完成音效。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="93"/>
+        <source>ATS Message Options: /fse - Turns the finish SE off.</source>
+        <translation>ATS 消息选项：/fse - 关闭完成音效。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="94"/>
+        <source>ATS Message Options: \tse - Turns the terminate SE on.</source>
+        <translation>ATS 消息选项：\tse - 开启终止音效。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="95"/>
+        <source>ATS Message Options: /tse - Turns the terminate SE off.</source>
+        <translation>ATS 消息选项：/tse - 关闭终止音效。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="98"/>
+        <source>ATS Message Options: \pSE[file,x,y] - Play the &quot;file&quot; SE at volume x and pitch y.</source>
+        <translation>ATS 消息选项：\pSE[file,x,y] - 以音量 x 和音高 y 播放 "file" 音效。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="101"/>
+        <source>ATS Message Options: \pME[file,x,y] - Play the &quot;file&quot; ME at volume x and pitch y.</source>
+        <translation>ATS 消息选项：\pME[file,x,y] - 以音量 x 和音高 y 播放 "file" 音乐。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="104"/>
+        <source>ATS Message Options: \pANIM[x,n] - Play the animation with ID n over character x.</source>
+        <translation>ATS 消息选项：\pANIM[x,n] - 在角色 x 上播放 ID 为 n 的动画。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="107"/>
+        <source>ATS Message Options: \pBLN[x,n] - Play the balloon with ID n over character x.</source>
+        <translation>ATS 消息选项：\pBLN[x,n] - 在角色 x 上播放 ID 为 n 的气泡。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="111"/>
+        <source>Yanfly Message Core (YEP): \V[n] is replaced by the value of the nth variable.</source>
+        <translation>Yanfly Message Core (YEP)：\V[n] 被第 n 个变量的值替换。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="114"/>
+        <source>Yanfly Message Core (YEP): \N[n] is replaced by the name of the nth actor.</source>
+        <translation>Yanfly Message Core (YEP)：\N[n] 被第 n 个角色的名字替换。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="117"/>
+        <source>Yanfly Message Core (YEP): \P[n] is replaced by the name of the nth party member.</source>
+        <translation>Yanfly Message Core (YEP)：\P[n] 被第 n 个队员的名字替换。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="120"/>
+        <source>Yanfly Message Core (YEP): \G is replaced by the currency unit.</source>
+        <translation>Yanfly Message Core (YEP)：\G 被货币单位替换。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="123"/>
+        <source>Yanfly Message Core (YEP): \C[n] draws the subsequent text in the nth color.
+This tag should always be closed with \C[0] tag to reset the color to default.
+\C[n] uses the colors from img/system/Window.png file.</source>
+        <translation>Yanfly Message Core (YEP)：\C[n] 以第 n 种颜色绘制后续文本。
+此标签应始终用 \C[0] 标签闭合以将颜色重置为默认值。
+\C[n] 使用 img/system/Window.png 文件中的颜色。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="126"/>
+        <source>Yanfly Message Core (YEP): \I[n] is replaced by the nth icon.
+\I[n] uses the icons from img/system/IconSet.rpgmvp file.</source>
+        <translation>Yanfly Message Core (YEP)：\I[n] 被第 n 个图标替换。
+\I[n] 使用 img/system/IconSet.rpgmvp 文件中的图标。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="129"/>
+        <source>Yanfly Message Core (YEP): \{ increases the text size by one step.</source>
+        <translation>Yanfly Message Core (YEP)：\{ 将文本大小增加一级。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="132"/>
+        <source>Yanfly Message Core (YEP): \} descreases the text size by one step.</source>
+        <translation>Yanfly Message Core (YEP)：\} 将文本大小减少一级。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="135"/>
+        <source>Yanfly Message Core (YEP): \\ inserts a literal backslash (\).</source>
+        <translation>Yanfly Message Core (YEP)：\\ 插入一个字面反斜杠（\）。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="138"/>
+        <source>Yanfly Message Core (YEP): \$ opens the gold window.</source>
+        <translation>Yanfly Message Core (YEP)：\$ 打开金币窗口。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="139"/>
+        <source>Yanfly Message Core (YEP): \. waits 1/4th seconds.</source>
+        <translation>Yanfly Message Core (YEP)：\. 等待 1/4 秒。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="140"/>
+        <source>Yanfly Message Core (YEP): \| waits 1 second.</source>
+        <translation>Yanfly Message Core (YEP)：\| 等待 1 秒。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="141"/>
+        <source>Yanfly Message Core (YEP): \! waits for button input.</source>
+        <translation>Yanfly Message Core (YEP)：\! 等待按键输入。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="142"/>
+        <source>Yanfly Message Core (YEP): \&gt; displays the remaining text on same line all at once.</source>
+        <translation>Yanfly Message Core (YEP)：\&gt; 立即在同一行显示剩余文本。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="145"/>
+        <source>Yanfly Message Core (YEP): \&lt; cancels the effect that displays text all at once.</source>
+        <translation>Yanfly Message Core (YEP)：\&lt; 取消立即显示文本的效果。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="148"/>
+        <source>Yanfly Message Core (YEP): \^ does not wait for input after displaying text.</source>
+        <translation>Yanfly Message Core (YEP)：\^ 显示文本后不等待输入。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="153"/>
+        <source>Yanfly Message Core (YEP): \w[x] waits x frames (60 frames = 1 second). Message window only.</source>
+        <translation>Yanfly Message Core (YEP)：\w[x] 等待 x 帧（60 帧 = 1 秒）。仅消息窗口。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="158"/>
+        <source>Yanfly Message Core (YEP): \n&lt;x&gt; creates a name box with x string. Left side. Works for message window only.</source>
+        <translation>Yanfly Message Core (YEP)：\n&lt;x&gt; 创建一个带 x 字符串的名称框。左侧。仅适用于消息窗口。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="161"/>
+        <source>Yanfly Message Core (YEP): \nc&lt;x&gt; creates a name box with x string. Centered. Works for message window only.</source>
+        <translation>Yanfly Message Core (YEP)：\nc&lt;x&gt; 创建一个带 x 字符串的名称框。居中。仅适用于消息窗口。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="164"/>
+        <source>Yanfly Message Core (YEP): \nr&lt;x&gt; creates a name box with x string. Right side. Works for message window only.</source>
+        <translation>Yanfly Message Core (YEP)：\nr&lt;x&gt; 创建一个带 x 字符串的名称框。右侧。仅适用于消息窗口。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="169"/>
+        <source>Yanfly Message Core (YEP): if using word wrap mode, this will cause a line break.</source>
+        <translation>Yanfly Message Core (YEP)：如果使用自动换行模式，这将导致换行。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="174"/>
+        <source>Yanfly Message Core (YEP): \px[x] sets x position of text to x.</source>
+        <translation>Yanfly Message Core (YEP)：\px[x] 将文本的 x 坐标设置为 x。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="177"/>
+        <source>Yanfly Message Core (YEP): \py[x] sets y position of text to x.</source>
+        <translation>Yanfly Message Core (YEP)：\py[x] 将文本的 y 坐标设置为 x。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="182"/>
+        <source>Yanfly Message Core (YEP): \oc[x] sets outline color to x.</source>
+        <translation>Yanfly Message Core (YEP)：\oc[x] 将轮廓颜色设置为 x。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="185"/>
+        <source>Yanfly Message Core (YEP): \ow[x] sets outline width to x.</source>
+        <translation>Yanfly Message Core (YEP)：\ow[x] 将轮廓宽度设置为 x。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="190"/>
+        <source>Yanfly Message Core (YEP): \fr resets all font changes.</source>
+        <translation>Yanfly Message Core (YEP)：\fr 重置所有字体更改。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="193"/>
+        <source>Yanfly Message Core (YEP): \fs[x] changes font size to x.</source>
+        <translation>Yanfly Message Core (YEP)：\fs[x] 将字体大小更改为 x。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="196"/>
+        <source>Yanfly Message Core (YEP): \fn&lt;x&gt; changes font name to x.</source>
+        <translation>Yanfly Message Core (YEP)：\fn&lt;x&gt; 将字体名称更改为 x。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="199"/>
+        <source>Yanfly Message Core (YEP): \fb toggles font boldness.</source>
+        <translation>Yanfly Message Core (YEP)：\fb 切换字体加粗。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="200"/>
+        <source>Yanfly Message Core (YEP): \fi toggles font italic.</source>
+        <translation>Yanfly Message Core (YEP)：\fi 切换字体斜体。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="203"/>
+        <source>Yanfly Message Core (YEP): \af[x] shows face of actor x. Works for message window only.</source>
+        <translation>Yanfly Message Core (YEP)：\af[x] 显示角色 x 的头像。仅适用于消息窗口。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="206"/>
+        <source>Yanfly Message Core (YEP): \ac[x] writes out actor&apos;s class name.</source>
+        <translation>Yanfly Message Core (YEP)：\ac[x] 输出角色的职业名称。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="209"/>
+        <source>Yanfly Message Core (YEP): \an[x] writes out actor&apos;s nickname.</source>
+        <translation>Yanfly Message Core (YEP)：\an[x] 输出角色的昵称。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="214"/>
+        <source>Yanfly Message Core (YEP): \pf[x] shows face of party member x. Works for message window only.</source>
+        <translation>Yanfly Message Core (YEP)：\pf[x] 显示队员 x 的头像。仅适用于消息窗口。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="217"/>
+        <source>Yanfly Message Core (YEP): \pc[x] writes out party member x&apos;s class name.</source>
+        <translation>Yanfly Message Core (YEP)：\pc[x] 输出队员 x 的职业名称。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="220"/>
+        <source>Yanfly Message Core (YEP): \pn[x] writes out party member x&apos;s nickname.</source>
+        <translation>Yanfly Message Core (YEP)：\pn[x] 输出队员 x 的昵称。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="225"/>
+        <source>Yanfly Message Core (YEP): \nc[x] writes out class x&apos;s name.</source>
+        <translation>Yanfly Message Core (YEP)：\nc[x] 输出职业 x 的名称。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="228"/>
+        <source>Yanfly Message Core (YEP): \ni[x] writes out item x&apos;s name.</source>
+        <translation>Yanfly Message Core (YEP)：\ni[x] 输出物品 x 的名称。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="231"/>
+        <source>Yanfly Message Core (YEP): \nw[x] writes out weapon x&apos;s name.</source>
+        <translation>Yanfly Message Core (YEP)：\nw[x] 输出武器 x 的名称。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="234"/>
+        <source>Yanfly Message Core (YEP): \na writes out armor x&apos;s name.</source>
+        <translation>Yanfly Message Core (YEP)：\na 输出防具 x 的名称。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="237"/>
+        <source>Yanfly Message Core (YEP): \ns[x] writes out skill x&apos;s name.</source>
+        <translation>Yanfly Message Core (YEP)：\ns[x] 输出技能 x 的名称。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="240"/>
+        <source>Yanfly Message Core (YEP): \nt writes out state x&apos;s name.</source>
+        <translation>Yanfly Message Core (YEP)：\nt 输出状态 x 的名称。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="245"/>
+        <source>Yanfly Message Core (YEP): \ii[x] writes out item x&apos;s name including icon.</source>
+        <translation>Yanfly Message Core (YEP)：\ii[x] 输出物品 x 的名称（含图标）。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="248"/>
+        <source>Yanfly Message Core (YEP): \iw[x] writes out weapon x&apos;s name including icon.</source>
+        <translation>Yanfly Message Core (YEP)：\iw[x] 输出武器 x 的名称（含图标）。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="251"/>
+        <source>Yanfly Message Core (YEP): \ia[x] writes out armor x&apos;s weapon including icon.</source>
+        <translation>Yanfly Message Core (YEP)：\ia[x] 输出防具 x 的名称（含图标）。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="254"/>
+        <source>Yanfly Message Core (YEP): \is[x] writes out skill x&apos;s name including icon.</source>
+        <translation>Yanfly Message Core (YEP)：\is[x] 输出技能 x 的名称（含图标）。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/PluginSequences.hpp" line="257"/>
+        <source>Yanfly Message Core (YEP): \it[x] writes out state x&apos;s name including icon.</source>
+        <translation>Yanfly Message Core (YEP)：\it[x] 输出状态 x 的名称（含图标）。</translation>
+    </message>
+</context>
+<context>
+    <name>TranslationTable</name>
+    <message>
+        <location filename="../src/TranslationTable/TranslationTable.cpp" line="130"/>
+        <source>Remove Row</source>
+        <translation>移除行</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/TranslationTable.cpp" line="132"/>
+        <source>Bookmark Row</source>
+        <translation>书签行</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/TranslationTable.cpp" line="158"/>
+        <source>Translation</source>
+        <translation>翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/TranslationTable.cpp" line="249"/>
+        <source>Cell is not empty</source>
+        <translation>单元格不为空</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/TranslationTable.cpp" line="250"/>
+        <source>Selected cell is not empty. Overwrite its contents with the translation?</source>
+        <translation>所选单元格不为空。是否用翻译覆盖其内容？</translation>
+    </message>
+</context>
+<context>
+    <name>TranslationsMenu</name>
+    <message>
+        <location filename="../src/TranslationsMenu/TranslationsMenu.cpp" line="23"/>
+        <source>Translations Menu</source>
+        <translation>翻译菜单</translation>
+    </message>
+</context>
+<context>
+    <name>WriteMenu</name>
+    <message>
+        <location filename="../src/WriteMenu/WriteMenu.ui" line="41"/>
+        <source>Apply</source>
+        <translation>应用</translation>
+    </message>
+</context>
+<context>
+    <name>mainWindow</name>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="122"/>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1081"/>
+        <source>Tab Panel</source>
+        <translation>标签面板</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="163"/>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="204"/>
+        <source>Write</source>
+        <translation>写入</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="242"/>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1371"/>
+        <source>Open Folder</source>
+        <translation>打开文件夹</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="283"/>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="327"/>
+        <source>Batch Menu</source>
+        <translation>批量菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="371"/>
+        <source>Glossary Menu</source>
+        <translation>术语表菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="415"/>
+        <location filename="../src/MainWindow/MainWindow.ui" line="991"/>
+        <source>Match Menu</source>
+        <translation>匹配菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="459"/>
+        <source>Translations Menu</source>
+        <translation>翻译菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="503"/>
+        <source>Bookmarks</source>
+        <translation>书签</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="630"/>
+        <source>No Tasks</source>
+        <translation>无任务</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="640"/>
+        <source>Displays task progress, in processed lines/total lines format.</source>
+        <translation>以已处理行/总行数格式显示任务进度。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="711"/>
+        <source>Game Title</source>
+        <translation>游戏标题</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="771"/>
+        <location filename="../src/MainWindow/MainWindow.ui" line="883"/>
+        <source>Search Panel</source>
+        <translation>搜索面板</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="828"/>
+        <source>File</source>
+        <translation>文件</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="844"/>
+        <source>Help</source>
+        <translation>帮助</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="852"/>
+        <source>Language</source>
+        <translation>语言</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="918"/>
+        <source>- Filter by file -</source>
+        <translation>- 按文件筛选 -</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1089"/>
+        <source>Source Control</source>
+        <translation>源代码管理</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1186"/>
+        <source>Commit message...</source>
+        <translation>提交信息...</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1224"/>
+        <source>Commit</source>
+        <translation>提交</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1300"/>
+        <source>Changes</source>
+        <translation>更改</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1319"/>
+        <source>Refresh Changes</source>
+        <translation>刷新更改</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1348"/>
+        <source>Copy translation to root</source>
+        <translation>复制翻译到根目录</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1355"/>
+        <source>Commits</source>
+        <translation>提交记录</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1376"/>
+        <source>Exit</source>
+        <translation>退出</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1381"/>
+        <source>About RPGMTranslate</source>
+        <translation>关于 RPGMTranslate</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1386"/>
+        <source>Usage Documentation</source>
+        <translation>使用文档</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1401"/>
+        <source>Settings</source>
+        <translation>设置</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1406"/>
+        <source>Check For Updates</source>
+        <translation>检查更新</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1411"/>
+        <source>Recent Projects</source>
+        <translation>最近项目</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1416"/>
+        <source>Close Project</source>
+        <translation>关闭项目</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1421"/>
+        <source>Close Tab</source>
+        <translation>关闭标签页</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1424"/>
+        <source>Esc</source>
+        <translation>Esc</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1429"/>
+        <source>Check for source file changes</source>
+        <translation>检查源文件更改</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1434"/>
+        <source>Load Backup</source>
+        <translation>加载备份</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Summary

This PR adds a complete Simplified Chinese (zh_CN) translation for the RPGMTranslate Qt application.

## What's included

- **File**: `translations/rpgmtranslate.zh_CN.ts`
- **568 translated strings** across all UI contexts
- **0 unfinished translations** — all strings have been translated

## Coverage

The translation covers all UI contexts:
- MainWindow, TabPanel, SearchMenu, ReadMenu, WriteMenu, PurgeMenu
- SettingsWindow (Core, Appearance, Controls, Translation, Project tabs)
- BatchMenu, BookmarkMenu, GlossaryMenu, MatchMenu, TranslationsMenu
- AssetMenu, AssetPreviewWidget, MediaPlayer, SearchPanelDock
- SourceControlDock, AboutWindow, BackupSelectDialog
- PluginSequences (ATS, Yanfly Message Core documentation strings)
- TranslationTable, utilities

## Technical notes

- Uses Qt Linguist TS v2.1 format
- Language code: `zh_CN` (Simplified Chinese, China)
- CMakeLists.txt already uses `file(GLOB TRANSLATION_TS_FILES translations/*)` so the new file is automatically picked up — no build system changes needed
- XML validated and well-formed

## Testing

The translation file follows the same structure as the existing `rpgmtranslate.en.ts` and `rpgmtranslate.ru.ts` files. It can be tested by building the project with Qt Linguist Tools enabled and selecting Chinese in the application language settings.