### PR TITLE
Add Simplified Chinese (zh-CN) translation

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -1,5 +1,7 @@
 # rpgmtranslate-qt
 
+[English](./README.md) | [简体中文](./README.zh-CN.md)
+
 <p align="center">
     <img src="./icons/rpgmtranslate-logo.png" alt="Description" width="256"/>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rpgmtranslate-qt
 
-[README на русском](./README-ru.md)
+[README на русском](./README-ru.md) | [简体中文](./README.zh-CN.md)
 
 <p align="center">
     <img src="./icons/rpgmtranslate-logo.png" alt="Description" width="256"/>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,90 @@
+# rpgmtranslate-qt
+
+[README English](./README.md) · [README на русском](./README-ru.md)
+
+<p align="center">
+    <img src="./icons/rpgmtranslate-logo.png" alt="Description" width="256"/>
+</p>
+
+使用 C++23/Qt6 从头重写了[原版 RPGMTranslate 应用](https://github.com/RPG-Maker-Translation-Tools/rpgmtranslate)。
+
+![界面](./screenshots/gui.png)
+
+## 功能特点
+
+- [x] 跨平台、便携、快速、强大。
+- [x] 卓越性能，由底层 Rust/C++ 代码驱动。
+- [x] 支持 RPG Maker XP/VX/VXAce/MV/MZ，自动解密归档并解析文件。
+- [x] 简洁的纯文本格式，可手动编辑。
+- [x] 翻译可导出为其他格式——XLSX、CSV、XML、YAML 和 JSON。
+- [x] 内置 [CAT](https://en.wikipedia.org/wiki/Computer-assisted_translation) 辅助翻译功能，支持 40 多种语言。
+- [x] 以便利为导向的用户体验，支持书签、快捷键和高度可定制化的功能。
+- [x] 内置批量文件处理，包括批量翻译、批量去空格和批量文本换行。
+- [x] 集成机器翻译 API——Google Translate、DeepL、AI 端点、本地端点、OpenRouter。
+- [x] 集成资源检查器，可查看图像、视频、字体、脚本等内容。
+- [x] 集成拼写检查和高级检查功能，包括各类插件（如 Yanfly Message Core）标签的检查及信息提示。
+- [x] **部分**集成了 Git 客户端。
+- [x] **大概**集成了 LanguageTool。
+
+**功能请求：** 由于可以使用 Rust 和 C++ 实现几乎任何功能，欢迎提出您和其他人需要的功能请求，我们会实现它们。
+
+本程序在底层使用了以下工具：
+
+- [rvpacker-txt-rs-lib](https://github.com/RPG-Maker-Translation-Tools/rvpacker-txt-rs-lib) 用于解析 RPG Maker 文件中的文本并应用翻译。
+- [marshal-rs](https://github.com/RPG-Maker-Translation-Tools/marshal-rs) 用于将 RPG Maker XP/VX/VX Ace 文件解析为 JSON。
+- [rpgm-archive-decrypter-lib](https://github.com/RPG-Maker-Translation-Tools/rpgm-archive-decrypter-lib) 用于解密 `.rgss` RPG Maker XP/VX/VX Ace 归档。
+- [rpgm-asset-decrypter-lib](https://github.com/RPG-Maker-Translation-Tools/rpgm-asset-decrypter-lib) 用于解密 MV/MZ 资源。
+
+程序使用这些工具将文本解析为 `.txt` 文件，方便编辑，然后再将翻译后的内容写回原始格式。
+
+如果在使用程序时遇到困难，请查看顶部菜单中的 `帮助 > 使用文档` 选项。这可能会有帮助。
+
+## 发布版本
+
+发布版本发布在 [Releases](https://github.com/RPG-Maker-Translation-Tools/rpgmtranslate-qt/releases) 页面。
+
+Windows 版本需要 Windows 10 或 11。程序为静态链接，无需额外安装其他依赖。
+
+每个版本都需要 CPU 支持 **x86-64-v3**：Intel 从 Haswell（2013 年）起，AMD 从 Excavator（2015 年）起。更老的硬件需要从源码构建并使用更低的 `-march`。
+
+可执行文件使用 `upx --best --lzma --brute --ultra-brute --compress-exports=0` 压缩。
+
+在 Linux 上运行此程序需要安装[这些依赖项](https://RPG-Maker-Translation-Tools.github.io/rpgmtranslate-qt/development#getting-development-headers-on-linux)。
+
+## 文档
+
+完整文档位于 <https://RPG-Maker-Translation-Tools.github.io/rpgmtranslate-qt/>。
+
+### 安装
+
+请参阅[安装文档](https://RPG-Maker-Translation-Tools.github.io/rpgmtranslate-qt/installation)。
+
+### 开发
+
+请参阅[开发文档](https://RPG-Maker-Translation-Tools.github.io/rpgmtranslate-qt/development)。
+
+## 支持
+
+项目的维护者[我](https://github.com/savannstm)是来自东欧的贫困大学生。
+
+如果您愿意，请考虑通过以下方式支持我们：
+
+- [Ko-fi](https://ko-fi.com/savannstm)
+- [Patreon](https://www.patreon.com/cw/savannstm)
+- [Boosty](https://boosty.to/mcdeimos)
+
+即使您不支持，也没关系。我们会继续做下去。
+
+## 许可证
+
+本项目采用 [WTFPL](https://www.wtfpl.net/) 许可证。
+
+仓库中包含的第三方软件，许可证条件各异：
+
+- `icons` - 包含 [Google Material Symbols](https://fonts.google.com/icons)，采用 `Apache License Version 2.0` 许可证。
+- `src/3rdparty` - 包含第三方库：
+    - [fast_float](https://github.com/fastfloat/fast_float)，[MIT](licenses/fast_float)
+    - [jeaiii/itoa](https://github.com/jeaiii/itoa)，[MIT](licenses/jeaiii-itoa)
+    - [magic_enum](https://github.com/Neargye/magic_enum)，[MIT](licenses/magic_enum)
+    - [zmij](https://github.com/vitaut/zmij)，[MIT](licenses/zmij)
+    - [miniaudio](https://github.com/mackron/miniaudio)，[Unlicense](licenses/miniaudio)

--- a/resources.qrc
+++ b/resources.qrc
@@ -48,5 +48,6 @@
         <file>icons/rpgmtranslate-logo.png</file>
         <file alias="ru.qm">build/rpgmtranslate.ru.qm</file>
         <file alias="en.qm">build/rpgmtranslate.en.qm</file>
+        <file alias="zh.qm">build/rpgmtranslate.zh-CN.qm</file>
     </qresource>
 </RCC>

--- a/src/MainWindow/MainWindow.ui
+++ b/src/MainWindow/MainWindow.ui
@@ -854,6 +854,7 @@
     </property>
     <addaction name="actionRussian"/>
     <addaction name="actionEnglish"/>
+    <addaction name="actionChinese"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuLanguage"/>
@@ -1535,6 +1536,11 @@
   <action name="actionEnglish">
    <property name="text">
     <string notr="true">English</string>
+   </property>
+  </action>
+  <action name="actionChinese">
+   <property name="text">
+    <string notr="true">简体中文</string>
    </property>
   </action>
   <action name="actionSettings">

--- a/src/MainWindow/MainWindowConnections.cpp
+++ b/src/MainWindow/MainWindowConnections.cpp
@@ -57,6 +57,8 @@ void MainWindow::setupConnections() {
 
     connect(ui->actionRussian, &QAction::triggered, this, [this] -> void { retranslate(QLocale::Russian); });
 
+    connect(ui->actionChinese, &QAction::triggered, this, [this] -> void { retranslate(QLocale::Chinese); });
+
     connect(ui->actionCheckForUpdates, &QAction::triggered, this, [this] -> void { checkForUpdates(true); });
 
     connect(actionGoToRow, &QAction::triggered, this, &MainWindow::handleGoToRow);

--- a/src/SettingsWindow/SettingsWindow.cpp
+++ b/src/SettingsWindow/SettingsWindow.cpp
@@ -472,6 +472,9 @@ SettingsWindow::SettingsWindow(
         ui->styleSelect->addItem(style);
     }
 
+    ui->languageSelect->addItem(tr("English"), scast<i32>(QLocale::English));
+    ui->languageSelect->addItem(tr("Russian"), scast<i32>(QLocale::Russian));
+    ui->languageSelect->addItem(tr("Chinese (Simplified)"), scast<i32>(QLocale::Chinese));
 
     const QList<std::pair<QString, QString>> languageTags = listLanguageTags();
 

--- a/translations/rpgmtranslate.zh-CN.ts
+++ b/translations/rpgmtranslate.zh-CN.ts
@@ -1,0 +1,2964 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>AboutWindow</name>
+    <message>
+        <location filename="../src/AboutWindow/AboutWindow.ui" line="35"/>
+        <location filename="../src/AboutWindow/AboutWindow.ui" line="97"/>
+        <source>About RPGMTranslate</source>
+        <translation>关于 RPGMTranslate</translation>
+    </message>
+    <message>
+        <location filename="../src/AboutWindow/AboutWindow.cpp" line="178"/>
+        <source>Failed to load THIRD-PARTY-NOTICE.md: %1. It usually comes bundled with RPGMTranslate.</source>
+        <translation>加载 THIRD-PARTY-NOTICE.md 失败：%1。该文件通常随 RPGMTranslate 一起提供。</translation>
+    </message>
+    <message>
+        <location filename="../src/AboutWindow/AboutWindow.ui" line="135"/>
+        <source>Third Party Notice</source>
+        <translation>第三方声明</translation>
+    </message>
+</context>
+<context>
+    <name>AssetMenu</name>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="109"/>
+        <source>Audio</source>
+        <translation>音频</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="110"/>
+        <source>Data</source>
+        <translation>数据</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="113"/>
+        <source>Fonts</source>
+        <translation>字体</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="112"/>
+        <source>Icons</source>
+        <translation>图标</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="111"/>
+        <source>Images</source>
+        <translation>图像</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="115"/>
+        <source>JS</source>
+        <translation>JS</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="114"/>
+        <source>Movies</source>
+        <translation>视频</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetMenu.cpp" line="31"/>
+        <source>Search file...</source>
+        <translation>搜索文件…</translation>
+    </message>
+</context>
+<context>
+    <name>AssetPreviewWidget</name>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="114"/>
+        <source> pt</source>
+        <translation> pt</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="414"/>
+        <source>Any</source>
+        <translation>任意</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="432"/>
+        <source>Arabic</source>
+        <translation>阿拉伯语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="426"/>
+        <source>Armenian</source>
+        <translation>亚美尼亚语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="590"/>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="606"/>
+        <source>Asset playback is disabled. You can open asset in the default app.</source>
+        <translation>资源播放已禁用。您可以在默认应用中打开资源。</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="56"/>
+        <source>Beautify</source>
+        <translation>美化</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="444"/>
+        <source>Bengali</source>
+        <translation>孟加拉语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="423"/>
+        <source>Cyrillic</source>
+        <translation>西里尔文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="441"/>
+        <source>Devanagari</source>
+        <translation>天城文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="322"/>
+        <source>Extension is unsupported.</source>
+        <translation>不支持的扩展名。</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="364"/>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="545"/>
+        <source>Failed to decrypt asset %1: %2</source>
+        <translation>解密资源 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="247"/>
+        <source>Failed to format: %1</source>
+        <translation>格式化失败：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="639"/>
+        <source>Failed to generate JSON for file %1: %2</source>
+        <translation>为文件 %1 生成 JSON 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="348"/>
+        <source>Failed to load asset %1: %2</source>
+        <translation>加载资源 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="398"/>
+        <source>Failed to load font %1</source>
+        <translation>加载字体 %1 失败</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="374"/>
+        <source>Failed to load pixmap from %1</source>
+        <translation>从 %1 加载像素图失败</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="617"/>
+        <source>Failed to open file %1: %2</source>
+        <translation>打开文件 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="556"/>
+        <source>Failed to open temporary file %1: %2</source>
+        <translation>打开临时文件 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="483"/>
+        <source>Georgian</source>
+        <translation>格鲁吉亚语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="420"/>
+        <source>Greek</source>
+        <translation>希腊语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="450"/>
+        <source>Gujarati</source>
+        <translation>古吉拉特语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="447"/>
+        <source>Gurmukhi</source>
+        <translation>古木基文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="429"/>
+        <source>Hebrew</source>
+        <translation>希伯来语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="738"/>
+        <source>Invalid regex</source>
+        <translation>无效的正则表达式</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="495"/>
+        <source>Japanese</source>
+        <translation>日语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="462"/>
+        <source>Kannada</source>
+        <translation>卡纳达语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="486"/>
+        <source>Khmer</source>
+        <translation>高棉语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="498"/>
+        <source>Korean</source>
+        <translation>韩语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="474"/>
+        <source>Lao</source>
+        <translation>老挝语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="417"/>
+        <source>Latin</source>
+        <translation>拉丁文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="52"/>
+        <source>Locate file</source>
+        <translation>定位文件</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="465"/>
+        <source>Malayalam</source>
+        <translation>马拉雅拉姆语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="100"/>
+        <source>Media playback not available</source>
+        <translation>媒体播放不可用</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="480"/>
+        <source>Myanmar</source>
+        <translation>缅甸语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="513"/>
+        <source>Nko</source>
+        <translation>曼丁哥文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="762"/>
+        <source>No results</source>
+        <translation>无结果</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="507"/>
+        <source>Ogham</source>
+        <translation>欧甘文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="53"/>
+        <source>Open in default app</source>
+        <translation>在默认应用中打开</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="453"/>
+        <source>Oriya</source>
+        <translation>奥利亚语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="510"/>
+        <source>Runic</source>
+        <translation>如尼文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="489"/>
+        <source>Simplified Chinese</source>
+        <translation>简体中文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="468"/>
+        <source>Sinhala</source>
+        <translation>僧伽罗语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="520"/>
+        <source>Supported writing systems: </source>
+        <translation>支持的书写系统：</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="504"/>
+        <source>Symbol</source>
+        <translation>符号</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="435"/>
+        <source>Syriac</source>
+        <translation>叙利亚语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="456"/>
+        <source>Tamil</source>
+        <translation>泰米尔语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="459"/>
+        <source>Telugu</source>
+        <translation>泰卢固语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="438"/>
+        <source>Thaana</source>
+        <translation>塔安纳文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="471"/>
+        <source>Thai</source>
+        <translation>泰语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="111"/>
+        <source>The quick brown fox jumps over the lazy dog</source>
+        <translation>敏捷的棕色狐狸跳过懒狗</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="477"/>
+        <source>Tibetan</source>
+        <translation>藏语</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="492"/>
+        <source>Traditional Chinese</source>
+        <translation>繁体中文</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/AssetPreviewWidget.cpp" line="501"/>
+        <source>Vietnamese</source>
+        <translation>越南语</translation>
+    </message>
+</context>
+<context>
+    <name>BackupSelectDialog</name>
+    <message>
+        <location filename="../src/BackupSelectDialog/BackupSelectDialog.hpp" line="22"/>
+        <source>Load</source>
+        <translation>加载</translation>
+    </message>
+    <message>
+        <location filename="../src/BackupSelectDialog/BackupSelectDialog.hpp" line="23"/>
+        <source>Once you click load, your current progress will be LOST! All current changes will be overwritten by a backup and the project will be reloaded.</source>
+        <translation>点击加载后，您当前的进度将丢失！所有当前更改将被备份覆盖，项目将重新加载。</translation>
+    </message>
+    <message>
+        <location filename="../src/BackupSelectDialog/BackupSelectDialog.hpp" line="55"/>
+        <source>This backup was created %1.</source>
+        <translation>此备份创建于 %1。</translation>
+    </message>
+</context>
+<context>
+    <name>BatchMenu</name>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="57"/>
+        <source>- Batch Action -</source>
+        <translation>- 批量操作 -</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="85"/>
+        <source>- Translation Column -</source>
+        <translation>- 翻译列 -</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="76"/>
+        <source>- Translation Endpoint -</source>
+        <translation>- 翻译端点 -</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="170"/>
+        <source>Context</source>
+        <translation>上下文</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="235"/>
+        <source>Failed to save scripts:
+%1</source>
+        <translation>保存脚本失败：
+%1</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="298"/>
+        <source>Latinize</source>
+        <translation>拉丁化</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="419"/>
+        <source>Leading</source>
+        <translation>仅前导</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="429"/>
+        <source>Leading + Trailing</source>
+        <translation>前导 + 尾随</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="178"/>
+        <source>New Script</source>
+        <translation>新建脚本</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="235"/>
+        <source>Process</source>
+        <translation>处理</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="67"/>
+        <source>Script</source>
+        <translation>脚本</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="81"/>
+        <source>Select files you want to process in file select menu.</source>
+        <translation>请在文件选择菜单中选择要处理的文件。</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="53"/>
+        <source>Select the batch action you want to perform.</source>
+        <translation>请选择要执行的批量操作。</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="58"/>
+        <source>Select the translation column you want perform the action in.</source>
+        <translation>请选择要执行操作的翻译列。</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="70"/>
+        <source>Select the translation endpoint you want to use.</source>
+        <translation>请选择要使用的翻译端点。</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="424"/>
+        <source>Trailing</source>
+        <translation>仅尾随</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="62"/>
+        <source>Translate</source>
+        <translation>翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="288"/>
+        <source>Trim</source>
+        <translation>去空格</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="201"/>
+        <source>Use File Context</source>
+        <translation>使用文件上下文</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="387"/>
+        <source>Use value from settings</source>
+        <translation>使用设置中的值</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.ui" line="293"/>
+        <source>Wrap</source>
+        <translation>换行</translation>
+    </message>
+    <message>
+        <location filename="../src/BatchMenu/BatchMenu.cpp" line="74"/>
+        <source>Wrap length input requires a number from 20 to 255.</source>
+        <translation>换行长度输入需要 20 到 255 之间的数字。</translation>
+    </message>
+</context>
+<context>
+    <name>BookmarkListDelegate</name>
+    <message>
+        <location filename="../src/BookmarkMenu/BookmarkList.cpp" line="149"/>
+        <source>Row %1 / File %2</source>
+        <translation>第 %1 行 / 文件 %2</translation>
+    </message>
+</context>
+<context>
+    <name>BookmarkMenu</name>
+    <message>
+        <location filename="../src/BookmarkMenu/BookmarkMenu.cpp" line="18"/>
+        <location filename="../src/BookmarkMenu/BookmarkMenu.cpp" line="95"/>
+        <source>- Filter by file -</source>
+        <translation>- 按文件筛选 -</translation>
+    </message>
+</context>
+<context>
+    <name>CBSLIWidget</name>
+    <message>
+        <location filename="../src/CBSLIWidget/CBSLIWidget.cpp" line="6"/>
+        <location filename="../src/CBSLIWidget/CBSLIWidget.cpp" line="35"/>
+        <source>Custom</source>
+        <translation>自定义</translation>
+    </message>
+</context>
+<context>
+    <name>FileSelectMenu</name>
+    <message>
+        <location filename="../src/FileSelectMenu/FileSelectMenu.ui" line="127"/>
+        <source>Deselect All</source>
+        <translation>取消全选</translation>
+    </message>
+    <message>
+        <location filename="../src/FileSelectMenu/FileSelectMenu.ui" line="120"/>
+        <source>Select All</source>
+        <translation>全选</translation>
+    </message>
+</context>
+<context>
+    <name>GitFileList</name>
+    <message>
+        <location filename="../src/SourceControlDock/GitFileList.hpp" line="527"/>
+        <source>Revert Selected</source>
+        <translation>还原所选</translation>
+    </message>
+    <message>
+        <location filename="../src/SourceControlDock/GitFileList.hpp" line="526"/>
+        <source>Stage Selected</source>
+        <translation>暂存所选</translation>
+    </message>
+</context>
+<context>
+    <name>GlossaryMenu</name>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.ui" line="179"/>
+        <source>Actions</source>
+        <translation>操作</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="173"/>
+        <source>Are you sure you want to delete this entry?</source>
+        <translation>确定要删除此条目吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="173"/>
+        <source>Confirm Delete</source>
+        <translation>确认删除</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="154"/>
+        <source>Empty term is not allowed.</source>
+        <translation>不允许空术语。</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="160"/>
+        <source>Empty term translation is not allowed.</source>
+        <translation>不允许空术语翻译。</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="96"/>
+        <source>No match found for: %1</source>
+        <translation>未找到匹配项：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.ui" line="174"/>
+        <source>Note</source>
+        <translation>备注</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.ui" line="88"/>
+        <source>Search Input</source>
+        <translation>搜索输入</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.ui" line="164"/>
+        <source>Term</source>
+        <translation>术语</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.ui" line="169"/>
+        <source>Translation</source>
+        <translation>翻译</translation>
+    </message>
+</context>
+<context>
+    <name>LintSelectMenu</name>
+    <message>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="143"/>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="222"/>
+        <source>All</source>
+        <translation>全部</translation>
+    </message>
+    <message>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="190"/>
+        <source>Comment Tags</source>
+        <translation>注释标签</translation>
+    </message>
+    <message>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="201"/>
+        <source>Custom Lints</source>
+        <translation>自定义检查</translation>
+    </message>
+    <message>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="53"/>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="70"/>
+        <source>Lints</source>
+        <translation>检查</translation>
+    </message>
+    <message>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="137"/>
+        <source>No lints in this category.</source>
+        <translation>此类别中无检查项。</translation>
+    </message>
+    <message>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="184"/>
+        <source>Note Tags</source>
+        <translation>备注标签</translation>
+    </message>
+    <message>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="186"/>
+        <source>Plugin Commands</source>
+        <translation>插件命令</translation>
+    </message>
+    <message>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="54"/>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="71"/>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="216"/>
+        <source>Terms</source>
+        <translation>术语</translation>
+    </message>
+    <message>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="183"/>
+        <source>Text Codes</source>
+        <translation>文本代码</translation>
+    </message>
+    <message>
+        <location filename="../src/LintSelectMenu/LintSelectMenu.cpp" line="210"/>
+        <source>The glossary is empty.</source>
+        <translation>术语表为空。</translation>
+    </message>
+</context>
+<context>
+    <name>LintTableModel</name>
+    <message>
+        <location filename="../src/LintMenu/LintTable.cpp" line="197"/>
+        <source>File</source>
+        <translation>文件</translation>
+    </message>
+    <message>
+        <location filename="../src/LintMenu/LintTable.cpp" line="205"/>
+        <source>Info</source>
+        <translation>信息</translation>
+    </message>
+    <message>
+        <location filename="../src/LintMenu/LintTable.cpp" line="199"/>
+        <source>Line</source>
+        <translation>行</translation>
+    </message>
+    <message>
+        <location filename="../src/LintMenu/LintTable.cpp" line="201"/>
+        <source>Source</source>
+        <translation>原文</translation>
+    </message>
+    <message>
+        <location filename="../src/LintMenu/LintTable.cpp" line="203"/>
+        <source>Translation</source>
+        <translation>翻译</translation>
+    </message>
+</context>
+<context>
+    <name>LintTooltip</name>
+    <message>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="208"/>
+        <source>Actor&apos;s name: %1</source>
+        <translation>角色名称：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="302"/>
+        <source>Enemy name: %1</source>
+        <translation>敌人名称：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="152"/>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="230"/>
+        <source>Failed to fetch data: %1</source>
+        <translation>获取数据失败：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="162"/>
+        <source>Failed to fetch icon: %1</source>
+        <translation>获取图标失败：%1</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="247"/>
+        <source>Here, the game will wait %n frame(s) (%1 sec.)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="571"/>
+        <source>Not yet implemented - work in progress.</source>
+        <translation>尚未实现——开发中。</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="542"/>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="605"/>
+        <source>Suggestions: %1</source>
+        <translation>建议：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="228"/>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="344"/>
+        <source>The following color will take effect: %1</source>
+        <translation>以下颜色将生效：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="183"/>
+        <source>The value of this variable will be displayed: %1</source>
+        <translation>将显示此变量的值：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="205"/>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="221"/>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="242"/>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="267"/>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="305"/>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="339"/>
+        <source>This pattern will be replaced with: %1</source>
+        <translation>此模式将被替换为：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="330"/>
+        <source>This pattern will be replaced with: %1%2</source>
+        <translation>此模式将被替换为：%1%2</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/LintTooltip.cpp" line="278"/>
+        <source>This pattern will be replaced with: %2</source>
+        <translation>此模式将被替换为：%2</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="1116"/>
+        <source>
+
+Skipped files:
+%1</source>
+        <translation>
+
+跳过的文件：
+%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="1164"/>
+        <source>%1
+
+The files have been changed. Do you want to append any new text?%2</source>
+        <translation>%1
+
+文件已更改。是否要追加任何新文本？%2</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="227"/>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="918"/>
+        <source>%1 Lines / %2 Comments</source>
+        <translation>%1 行 / %2 条注释</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="210"/>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="922"/>
+        <source>%1 Translated / %2 Total</source>
+        <translation>%1 已翻译 / 共 %2</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="240"/>
+        <source>%n row(s) copied.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="237"/>
+        <source>%n row(s) cut.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="243"/>
+        <source>%n row(s) pasted.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="430"/>
+        <source>%n task(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="919"/>
+        <source>- Filter by file -</source>
+        <translation>- 按文件筛选 -</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="199"/>
+        <source>Abort</source>
+        <translation>中止</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1522"/>
+        <source>About RPGMTranslate</source>
+        <translation>关于 RPGMTranslate</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="1204"/>
+        <source>All source files are up-to-date.%1</source>
+        <translation>所有源文件均为最新版本。%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="825"/>
+        <source>Another task is already running.</source>
+        <translation>已有其他任务正在运行。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="172"/>
+        <source>Assets</source>
+        <translation>资源</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowSaveLoad.cpp" line="233"/>
+        <source>Backup %1 created.</source>
+        <translation>已创建备份 %1。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="327"/>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="165"/>
+        <source>Batch Menu</source>
+        <translation>批量菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="325"/>
+        <source>Batch translation failed with error: %1</source>
+        <translation>批量翻译失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="619"/>
+        <source>Before working with the program, check out documentation in Help &gt; Documentation!</source>
+        <translation>使用本程序前，请先参阅帮助 &gt; 文档！</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="170"/>
+        <source>Bookmark Menu</source>
+        <translation>书签菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="503"/>
+        <source>Bookmarks</source>
+        <translation>书签</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="255"/>
+        <source>Cannot perform batch-translate. You need to set source language in Settings &gt; Project first.</source>
+        <translation>无法执行批量翻译。请先在设置 &gt; 项目中设置源语言。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="267"/>
+        <source>Cannot perform batch-translate. You need to set translation language in Settings &gt; Project first.</source>
+        <translation>无法执行批量翻译。请先在设置 &gt; 项目中设置翻译语言。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="1012"/>
+        <source>Cannot start %1 while %2 is running.</source>
+        <translation>无法在 %2 运行时启动 %1。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="115"/>
+        <source>Cannot write, source files are absent.</source>
+        <translation>无法写入，源文件不存在。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="1150"/>
+        <source>Changed files: [%1]</source>
+        <translation>已更改的文件：[%1]</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1441"/>
+        <source>Changes</source>
+        <translation>更改</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1547"/>
+        <source>Check For Updates</source>
+        <translation>检查更新</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1570"/>
+        <source>Check for source updates</source>
+        <translation>检查源文件更新</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1557"/>
+        <source>Close Project</source>
+        <translation>关闭项目</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1562"/>
+        <source>Close Tab</source>
+        <translation>关闭标签页</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1375"/>
+        <source>Commit</source>
+        <translation>提交</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1341"/>
+        <source>Commit message...</source>
+        <translation>提交信息…</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1496"/>
+        <source>Commits</source>
+        <translation>提交记录</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1489"/>
+        <source>Copy translation to root</source>
+        <translation>复制翻译到根目录</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="655"/>
+        <source>Copying the data directory to .rpgmtranslate/baseline-data as a baseline.</source>
+        <translation>正在将数据目录复制到 .rpgmtranslate/baseline-data 作为基线数据。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1066"/>
+        <source>Disable linting (overrides settings)</source>
+        <translation>禁用检查（覆盖设置）</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="186"/>
+        <source>Don&apos;t remind me</source>
+        <translation>不再提醒</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1565"/>
+        <source>Esc</source>
+        <translation>Esc</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="743"/>
+        <source>Existing translation folder</source>
+        <translation>现有翻译文件夹</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1517"/>
+        <source>Exit</source>
+        <translation>退出</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="346"/>
+        <source>Export failed with error: %1</source>
+        <translation>导出失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="156"/>
+        <source>Export/Import</source>
+        <translation>导出/导入</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="667"/>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="1183"/>
+        <source>Failed to copy %1 to %2 as a baseline data: %3. The original source data from the root will be used instead.</source>
+        <translation>无法将 %1 复制到 %2 作为基线数据：%3。将使用根目录中的原始源数据代替。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="155"/>
+        <source>Failed to extract update archive.</source>
+        <translation>解压更新归档失败。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="722"/>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="836"/>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="862"/>
+        <source>Failed to load project: %1</source>
+        <translation>加载项目失败：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="642"/>
+        <source>Failed to open git repository with error: %1</source>
+        <translation>打开 Git 仓库失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="903"/>
+        <source>Failed to open tab: %1.</source>
+        <translation>打开标签页失败：%1。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="86"/>
+        <source>Failed to open update archive.</source>
+        <translation>打开更新归档失败。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="266"/>
+        <source>Failed to opened project because couldn&apos;t locate `.rpgmtranslate` program directory that was previously located at this path: %1. If this is intentional, please reopen the directory manually.</source>
+        <translation>无法打开项目，因为找不到之前位于此路径的 `.rpgmtranslate` 程序目录：%1。如果是故意的，请手动重新打开目录。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="157"/>
+        <source>Failed to retranslate the interface. This is most like an internal application issue.</source>
+        <translation>重新翻译界面失败。这很可能是应用程序内部问题。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="827"/>
+        <source>File</source>
+        <translation>文件</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="894"/>
+        <source>File is currently processed and is being locked.</source>
+        <translation>文件正在处理中，已被锁定。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="255"/>
+        <source>Folder %1 does not exist.</source>
+        <translation>文件夹 %1 不存在。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="710"/>
+        <source>Game Title</source>
+        <translation>游戏标题</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1221"/>
+        <source>Global Check</source>
+        <translation>全局检查</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="371"/>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="166"/>
+        <source>Glossary Menu</source>
+        <translation>术语表菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1122"/>
+        <source>Glossary check (configure glossary)</source>
+        <translation>术语表检查（配置术语表）</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="843"/>
+        <source>Help</source>
+        <translation>帮助</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="371"/>
+        <source>Import failed with error: %1</source>
+        <translation>导入失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="88"/>
+        <source>Input line from %1 to %2</source>
+        <translation>输入行从 %1 到 %2</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="189"/>
+        <source>Install</source>
+        <translation>安装</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="199"/>
+        <source>Installing update...</source>
+        <translation>正在安装更新…</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="853"/>
+        <source>Language</source>
+        <translation>语言</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1115"/>
+        <source>LanguageTool (configure in settings)</source>
+        <translation>LanguageTool（在设置中配置）</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="415"/>
+        <location filename="../src/MainWindow/MainWindow.ui" line="992"/>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="167"/>
+        <source>Lint Menu</source>
+        <translation>检查菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1087"/>
+        <source>Lint contiguous whitespace</source>
+        <translation>检查连续空白</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1073"/>
+        <source>Lint leading whitespace</source>
+        <translation>检查前导空白</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1101"/>
+        <source>Lint source/translation tag mismatch</source>
+        <translation>检查原文/译文标签不匹配</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1080"/>
+        <source>Lint trailing whitespace</source>
+        <translation>检查尾随空白</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1094"/>
+        <source>Lint unclosed punctuation</source>
+        <translation>检查未闭合标点</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1214"/>
+        <source>Lints</source>
+        <translation>检查</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1575"/>
+        <source>Load Backup</source>
+        <translation>加载备份</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="174"/>
+        <source>Locate Project Directory</source>
+        <translation>定位项目目录</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="1158"/>
+        <source>New files: [%1]</source>
+        <translation>新文件：[%1]</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="187"/>
+        <source>New version is available</source>
+        <translation>有新版本可用</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="1109"/>
+        <source>No matching source files were found in:
+%1</source>
+        <translation>在以下位置未找到匹配的源文件：
+%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="645"/>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="430"/>
+        <source>No tasks</source>
+        <translation>无任务</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="242"/>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1512"/>
+        <source>Open Folder</source>
+        <translation>打开文件夹</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.cpp" line="136"/>
+        <source>Open a project by using &apos;Open Folder&apos; button!</source>
+        <translation>请使用「打开文件夹」按钮打开项目！</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowSaveLoad.cpp" line="376"/>
+        <source>Opening backup %1 failed: %2</source>
+        <translation>打开备份 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="177"/>
+        <source>Program is up-to-date.</source>
+        <translation>程序已是最新版本。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="129"/>
+        <source>Program was compiled without support for libgit2, so it&apos;s impossible to access source control.</source>
+        <translation>程序编译时未包含 libgit2 支持，因此无法访问版本控制。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="155"/>
+        <source>Purge</source>
+        <translation>清除</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="321"/>
+        <source>Purge failed with error: %1</source>
+        <translation>清除失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="154"/>
+        <source>Read</source>
+        <translation>读取</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="1242"/>
+        <source>Read failed: %1</source>
+        <translation>读取失败：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="818"/>
+        <source>Read was rejected by user.</source>
+        <translation>读取被用户拒绝。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowSaveLoad.cpp" line="387"/>
+        <source>Reading archive failed with %1</source>
+        <translation>读取归档失败：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1552"/>
+        <source>Recent Projects</source>
+        <translation>最近的项目</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1460"/>
+        <source>Refresh Changes</source>
+        <translation>刷新更改</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="478"/>
+        <source>Replace failed, unable to open file %1</source>
+        <translation>替换失败，无法打开文件 %1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="642"/>
+        <source>Running tasks</source>
+        <translation>正在运行的任务</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="163"/>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="162"/>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="299"/>
+        <source>Script failed at %1, line %2: %3</source>
+        <translation>脚本在 %1，第 %2 行执行失败：%3</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="295"/>
+        <source>Script failed: %1</source>
+        <translation>脚本执行失败：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="283"/>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="164"/>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="770"/>
+        <location filename="../src/MainWindow/MainWindow.ui" line="884"/>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="175"/>
+        <source>Search Panel</source>
+        <translation>搜索面板</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="281"/>
+        <source>Select a game folder</source>
+        <translation>选择游戏文件夹</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="588"/>
+        <source>Set source and translation languages in Settings &gt; Project to show glossary matches.</source>
+        <translation>请在设置 &gt; 项目中设置源语言和翻译语言以显示术语表匹配。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="651"/>
+        <source>Set source and translation languages in Settings &gt; Project to show translations.</source>
+        <translation>请在设置 &gt; 项目中设置源语言和翻译语言以显示翻译。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="590"/>
+        <source>Set source language in Settings &gt; Project to show glossary matches.</source>
+        <translation>请在设置 &gt; 项目中设置源语言以显示术语表匹配。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="653"/>
+        <source>Set source language in Settings &gt; Project to show translations.</source>
+        <translation>请在设置 &gt; 项目中设置源语言以显示翻译。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="585"/>
+        <source>Set translation language in Settings &gt; Project to show glossary matches.</source>
+        <translation>请在设置 &gt; 项目中设置翻译语言以显示术语表匹配。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="648"/>
+        <source>Set translation language in Settings &gt; Project to show translations.</source>
+        <translation>请在设置 &gt; 项目中设置翻译语言以显示翻译。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1542"/>
+        <source>Settings</source>
+        <translation>设置</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="190"/>
+        <source>Skip</source>
+        <translation>跳过</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="562"/>
+        <source>Source</source>
+        <translation>原文</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1244"/>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="171"/>
+        <source>Source Control</source>
+        <translation>版本控制</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="1163"/>
+        <source>Source files have been updated</source>
+        <translation>源文件已更新</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="805"/>
+        <source>Source files, translation or archive file do not exist.</source>
+        <translation>源文件、翻译或归档文件不存在。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1108"/>
+        <source>Spellcheck (configure in settings)</source>
+        <translation>拼写检查（在设置中配置）</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowSaveLoad.cpp" line="119"/>
+        <source>Tab %1 saved.</source>
+        <translation>标签页 %1 已保存。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="122"/>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1236"/>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="161"/>
+        <source>Tab Panel</source>
+        <translation>标签页面板</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="625"/>
+        <source>The program failed to split some lines into parts because of absence of &lt;#&gt; delimiter. Check log to see skipped lines.</source>
+        <translation>程序因缺少 &lt;#&gt; 分隔符而无法将某些行拆分。请查看日志以了解跳过的行。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="1032"/>
+        <source>The program was unable to open the following files:
+ %1</source>
+        <translation>程序无法打开以下文件：
+ %1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="1039"/>
+        <source>The source path %1 does not exist.</source>
+        <translation>源路径 %1 不存在。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1580"/>
+        <source>Third Party Notice</source>
+        <translation>第三方声明</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="220"/>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="221"/>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="222"/>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="566"/>
+        <source>Translation</source>
+        <translation>翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="744"/>
+        <source>Translation folder is found in the root of the project. Use it?</source>
+        <translation>在项目根目录找到翻译文件夹。使用它？</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="459"/>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="169"/>
+        <source>Translations Menu</source>
+        <translation>翻译菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="225"/>
+        <source>Update failed with error: %1</source>
+        <translation>更新失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="1527"/>
+        <source>Usage Documentation</source>
+        <translation>使用文档</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowFunctions.cpp" line="188"/>
+        <source>Version %1 is available.
+Current version is %2.</source>
+        <translation>版本 %1 可用。
+当前版本为 %2。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindow.ui" line="204"/>
+        <location filename="../src/MainWindow/MainWindow.hpp" line="163"/>
+        <source>Write</source>
+        <translation>写入</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="133"/>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="397"/>
+        <source>Write failed: %1</source>
+        <translation>写入失败：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowSaveLoad.cpp" line="402"/>
+        <source>Writing entry %1 failed: %2</source>
+        <translation>写入条目 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowCallbacks.cpp" line="137"/>
+        <location filename="../src/MainWindow/MainWindowConnections.cpp" line="401"/>
+        <source>Written successfully. Elapsed: %1s.</source>
+        <translation>写入成功。耗时：%1 秒。</translation>
+    </message>
+    <message>
+        <location filename="../src/MainWindow/MainWindowSaveLoad.cpp" line="149"/>
+        <source>maps.txt saved.</source>
+        <translation>maps.txt 已保存。</translation>
+    </message>
+</context>
+<context>
+    <name>MediaPlayer</name>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="357"/>
+        <source>Done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="207"/>
+        <source>FFmpeg frame alloc failed</source>
+        <translation>FFmpeg 帧分配失败</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="199"/>
+        <source>FFmpeg frame/packet alloc failed</source>
+        <translation>FFmpeg 帧/数据包分配失败</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="192"/>
+        <source>Failed to open audio device for: %1</source>
+        <translation>无法打开音频设备：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="129"/>
+        <source>No playable stream (video or audio) found in: %1</source>
+        <translation>在 %1 中未找到可播放的流（视频或音频）</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="300"/>
+        <source>Pause</source>
+        <translation>暂停</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="300"/>
+        <source>Resume</source>
+        <translation>继续</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="214"/>
+        <source>av_malloc failed for RGB buffer</source>
+        <translation>av_malloc 为 RGB 缓冲区分配失败</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="93"/>
+        <source>avcodec_alloc_context3 failed for video</source>
+        <translation>avcodec_alloc_context3 为视频分配失败</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="109"/>
+        <source>avcodec_open2 (video): %1</source>
+        <translation>avcodec_open2（视频）：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="99"/>
+        <source>avcodec_parameters_to_context (video): %1</source>
+        <translation>avcodec_parameters_to_context（视频）：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="83"/>
+        <source>avformat_find_stream_info: %1</source>
+        <translation>avformat_find_stream_info：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="78"/>
+        <source>avformat_open_input: %1</source>
+        <translation>avformat_open_input：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="446"/>
+        <source>sws_getCachedContext failed</source>
+        <translation>sws_getCachedContext 失败</translation>
+    </message>
+</context>
+<context>
+    <name>Notice</name>
+    <message>
+        <location filename="../src/utilities/Notice.cpp" line="80"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../src/utilities/Notice.cpp" line="76"/>
+        <source>Information</source>
+        <translation>信息</translation>
+    </message>
+    <message>
+        <location filename="../src/utilities/Notice.cpp" line="78"/>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+</context>
+<context>
+    <name>PurgeMenu</name>
+    <message>
+        <location filename="../src/PurgeMenu/PurgeMenu.ui" line="88"/>
+        <source>Apply</source>
+        <translation>应用</translation>
+    </message>
+    <message>
+        <location filename="../src/PurgeMenu/PurgeMenu.ui" line="81"/>
+        <source>Close</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <location filename="../src/PurgeMenu/PurgeMenu.ui" line="53"/>
+        <source>Create .rvpacker-ignore file from purged lines to prevent their further appearance.</source>
+        <translation>从已清除的行创建 .rvpacker-ignore 文件，以防止它们再次出现。</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/utilities/Utils.cpp" line="34"/>
+        <source>Abort</source>
+        <translation>中止</translation>
+    </message>
+    <message>
+        <location filename="../src/utilities/Utils.cpp" line="30"/>
+        <source>Continue anyway</source>
+        <translation>仍然继续</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="263"/>
+        <source>Export</source>
+        <translation>导出</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="249"/>
+        <source>Extract archive</source>
+        <translation>解压归档</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="265"/>
+        <source>Import</source>
+        <translation>导入</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="261"/>
+        <source>Lint</source>
+        <translation>检查</translation>
+    </message>
+    <message>
+        <location filename="../src/AssetMenu/MediaPlayer.cpp" line="245"/>
+        <source>Pause</source>
+        <translation>暂停</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="247"/>
+        <source>Purge</source>
+        <translation>清除</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="243"/>
+        <source>Read</source>
+        <translation>读取</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="253"/>
+        <source>Replace</source>
+        <translation>替换</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="255"/>
+        <source>Replace single</source>
+        <translation>替换单个</translation>
+    </message>
+    <message>
+        <location filename="../src/utilities/Utils.cpp" line="31"/>
+        <source>Retry</source>
+        <translation>重试</translation>
+    </message>
+    <message>
+        <location filename="../src/utilities/Utils.cpp" line="33"/>
+        <source>Save to custom location</source>
+        <translation>保存到自定义位置</translation>
+    </message>
+    <message>
+        <location filename="../src/utilities/Utils.cpp" line="21"/>
+        <source>Saving file failed</source>
+        <translation>保存文件失败</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="257"/>
+        <source>Script</source>
+        <translation>脚本</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="251"/>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="259"/>
+        <source>Translate</source>
+        <translation>翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/utilities/Utils.cpp" line="23"/>
+        <source>Unable to save file %1: %2. You may try to save the file to a custom location. It&apos;s strongly advised to you to better close the program and fix the underlying issue before continuing your work.</source>
+        <translation>无法保存文件 %1：%2。您可以尝试将文件保存到自定义位置。强烈建议您关闭程序并修复底层问题后再继续工作。</translation>
+    </message>
+    <message>
+        <location filename="../src/utilities/Utils.cpp" line="20"/>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="245"/>
+        <source>Write</source>
+        <translation>写入</translation>
+    </message>
+</context>
+<context>
+    <name>ReadMenu</name>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="189"/>
+        <source>Allow Duplicates</source>
+        <translation>允许重复</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="60"/>
+        <source>Allow duplicates across maps and events. This may bloat your translation. This mode is always set for system, scripts, and plugins files.</source>
+        <translation>允许跨地图和事件重复。这可能会使翻译文件膨胀。系统、脚本和插件文件始终使用此模式。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="104"/>
+        <source>Append</source>
+        <translation>追加</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="45"/>
+        <source>Appends any new text from the game to the translation files, if the text is not already present. Lines order is sorted, unused lines go to the bottom of the map/event.</source>
+        <translation>将游戏中的任何新文本追加到翻译文件中（如果该文本尚不存在）。行顺序会被排序，未使用的行移到地图/事件的底部。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="37"/>
+        <source>Appends any new text from the game to the translation files, if the text is not already present. Lines order is sorted, unused lines go to the bottom of the map/event. Default mode does nothing, when the source files are unchanged since the last read - in this case use force append mode.</source>
+        <translation>将游戏中的任何新文本追加到翻译文件中（如果该文本尚不存在）。行顺序会被排序，未使用的行移到地图/事件的底部。默认模式下，当源文件自上次读取以来未更改时，不执行任何操作——此时请使用强制追加模式。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="502"/>
+        <source>Apply</source>
+        <translation>应用</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="495"/>
+        <source>Close</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="94"/>
+        <source>Default</source>
+        <translation>默认</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="22"/>
+        <source>Default mode does nothing when files are already read.</source>
+        <translation>默认模式下，当文件已被读取时不执行任何操作。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="120"/>
+        <source>Default mode does nothing, when the source files are unchanged since the last read - in this case use force append mode.</source>
+        <translation>默认模式下，当源文件自上次读取以来未更改时不执行任何操作——此时请使用强制追加模式。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="175"/>
+        <source>Duplicate Mode</source>
+        <translation>重复模式</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="86"/>
+        <source>Failed to extract title from the Game.ini file: %1</source>
+        <translation>从 Game.ini 文件中提取标题失败：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="99"/>
+        <source>Force</source>
+        <translation>强制</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="109"/>
+        <source>Force Append</source>
+        <translation>强制追加</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="31"/>
+        <source>Force rewrites existing translation files.</source>
+        <translation>强制重写现有翻译文件。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="279"/>
+        <source>Ignore: Ignore entries from .rvpacker-ignore file.</source>
+        <translation>忽略：忽略 .rvpacker-ignore 文件中的条目。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="379"/>
+        <source>Parse Map Events: Parses map events metadata, such as event ID, name, x/y position.</source>
+        <translation>解析地图事件：解析地图事件元数据，如事件 ID、名称、x/y 位置。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="28"/>
+        <source>Parses the game text.</source>
+        <translation>解析游戏文本。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="77"/>
+        <source>Read Mode</source>
+        <translation>读取模式</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="194"/>
+        <source>Remove Duplicates</source>
+        <translation>移除重复</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="205"/>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="65"/>
+        <source>Remove duplicates across maps and events. Recommended. In system, scripts and plugins files this mode is always overridden by allow mode.</source>
+        <translation>移除跨地图和事件的重复。建议使用。在系统、脚本和插件文件中，此模式始终被允许模式覆盖。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="332"/>
+        <source>Skip Obsolete: Don&apos;t preserve obsolete entries from the previous read.</source>
+        <translation>跳过已废弃：不要保留上一次读取中的已废弃条目。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.cpp" line="92"/>
+        <source>Title is empty in Game.ini file.</source>
+        <translation>Game.ini 文件中的标题为空。</translation>
+    </message>
+    <message>
+        <location filename="../src/ReadMenu/ReadMenu.ui" line="423"/>
+        <source>Use title from Game.ini: If game is RPG Maker XP/VX/VX Ace, it may not necessarily contain game title in the system file. Use this option to take it from Game.ini. You will have to pick the right encoding. If this option is not set, we&apos;ll try to use the title from system file, if it&apos;s there.</source>
+        <translation>使用 Game.ini 中的标题：如果游戏是 RPG Maker XP/VX/VX Ace，系统文件中可能不一定包含游戏标题。使用此选项从 Game.ini 中获取标题。您需要选择正确的编码。如果未设置此选项，我们将尝试使用系统文件中的标题（如果有的话）。</translation>
+    </message>
+</context>
+<context>
+    <name>SearchMenu</name>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="499"/>
+        <source>All Columns</source>
+        <translation>所有列</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="37"/>
+        <source>Do you really want to replace the text to nothing?</source>
+        <translation>确定要将文本替换为空吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="429"/>
+        <source>Files To Search</source>
+        <translation>要搜索的文件</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="265"/>
+        <source>Match Case</source>
+        <translation>区分大小写</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="485"/>
+        <source>Only Source</source>
+        <translation>仅原文</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="490"/>
+        <source>Only Translation</source>
+        <translation>仅译文</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="178"/>
+        <source>Put</source>
+        <translation>放入</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="140"/>
+        <source>Replace</source>
+        <translation>替换</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="17"/>
+        <source>Replace can only be performed in a certain column.</source>
+        <translation>替换只能在特定列中执行。</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="216"/>
+        <source>Replace input</source>
+        <translation>替换输入</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="36"/>
+        <source>Replace input is empty</source>
+        <translation>替换输入为空</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="504"/>
+        <source>Rightmost Column</source>
+        <translation>最右侧列</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="102"/>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="347"/>
+        <source>Search By Regular Expression</source>
+        <translation>使用正则表达式搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="480"/>
+        <source>Search Everywhere</source>
+        <translation>搜索所有位置</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="388"/>
+        <source>Search In Comments</source>
+        <translation>在注释中搜索</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="306"/>
+        <source>Search Whole</source>
+        <translation>搜索整个</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.ui" line="47"/>
+        <source>Search input</source>
+        <translation>搜索输入</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="24"/>
+        <source>Search input is empty.</source>
+        <translation>搜索输入为空。</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchMenu/SearchMenu.cpp" line="12"/>
+        <source>Select some files to process in file select menu.</source>
+        <translation>请在文件选择菜单中选择一些要处理的文件。</translation>
+    </message>
+</context>
+<context>
+    <name>SearchPanelDock</name>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="95"/>
+        <source>- Filter by file -</source>
+        <translation>- 按文件筛选 -</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="160"/>
+        <source>Confirmation</source>
+        <translation>确认</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="161"/>
+        <source>Do you really want to put the text from the replace input in place of this text, effectively replacing it?</source>
+        <translation>确定要将替换输入中的文本放到此文本的位置吗？这实际上是在替换它。</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="72"/>
+        <source>File %1 / Row %2 / Column %3 (%4)</source>
+        <translation>文件 %1 / 行 %2 / 列 %3 (%4)</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="77"/>
+        <source>Source</source>
+        <translation>原文</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="184"/>
+        <source>Source column cannot be replaced.</source>
+        <translation>无法替换原文列。</translation>
+    </message>
+    <message>
+        <location filename="../src/SearchPanelDock/SearchPanelDock.cpp" line="187"/>
+        <source>This result was already replaced.</source>
+        <translation>此结果已被替换。</translation>
+    </message>
+</context>
+<context>
+    <name>SerdeMenu</name>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.ui" line="127"/>
+        <source>Browse</source>
+        <translation>浏览</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.ui" line="71"/>
+        <source>CSV</source>
+        <translation>CSV</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.ui" line="155"/>
+        <source>Close</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.ui" line="169"/>
+        <source>Export</source>
+        <translation>导出</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.ui" line="120"/>
+        <source>Export destination / import source folder</source>
+        <translation>导出目标 / 导入源文件夹</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.ui" line="35"/>
+        <source>Export existing translation files into another format, or import previously-exported files back.</source>
+        <translation>将现有翻译文件导出为其他格式，或导入先前导出的文件。</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.ui" line="63"/>
+        <source>Format</source>
+        <translation>格式</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.ui" line="162"/>
+        <source>Import</source>
+        <translation>导入</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.ui" line="86"/>
+        <source>JSON</source>
+        <translation>JSON</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.cpp" line="64"/>
+        <source>Pick a destination folder first.</source>
+        <translation>请先选择目标文件夹。</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.cpp" line="71"/>
+        <location filename="../src/SerdeMenu/SerdeMenu.cpp" line="89"/>
+        <source>%1 support was not compiled into this build.</source>
+        <translation>此版本未编译入 %1 支持。</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.cpp" line="82"/>
+        <source>Pick a source folder first.</source>
+        <translation>请先选择源文件夹。</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.cpp" line="55"/>
+        <source>Select a folder</source>
+        <translation>选择一个文件夹</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.ui" line="76"/>
+        <source>XLSX</source>
+        <translation>XLSX</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.ui" line="81"/>
+        <source>XML</source>
+        <translation>XML</translation>
+    </message>
+    <message>
+        <location filename="../src/SerdeMenu/SerdeMenu.ui" line="91"/>
+        <source>YAML</source>
+        <translation>YAML</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1406"/>
+        <source>API key</source>
+        <translation>API 密钥</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1167"/>
+        <source>Add Endpoint</source>
+        <translation>添加端点</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="505"/>
+        <source>Appearance</source>
+        <translation>外观</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="163"/>
+        <source>Backup</source>
+        <translation>备份</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="194"/>
+        <source>Backup period</source>
+        <translation>备份周期</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="835"/>
+        <source>Backup period must be between %1 and %2 seconds.</source>
+        <translation>备份周期必须在 %1 到 %2 秒之间。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1476"/>
+        <source>Base URL</source>
+        <translation>基础 URL</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="815"/>
+        <source>Batch Menu</source>
+        <translation>批量菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="846"/>
+        <source>Bookmark Menu</source>
+        <translation>书签菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2289"/>
+        <source>Case insensitive</source>
+        <translation>不区分大小写</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2017"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2083"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2149"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2215"/>
+        <source>Category</source>
+        <translation>类别</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1842"/>
+        <source>Check connection</source>
+        <translation>检查连接</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="268"/>
+        <source>Check for source file updates</source>
+        <translation>检查源文件更新</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="258"/>
+        <source>Check for updates</source>
+        <translation>检查更新</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1513"/>
+        <source>Check key</source>
+        <translation>检查密钥</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="265"/>
+        <source>Check whether the game&apos;s source files changed since the last read, and offer to re-read them.</source>
+        <translation>检查游戏的源文件自上次读取以来是否已更改，并提示是否重新读取。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="726"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1047"/>
+        <source>Choose Color</source>
+        <translation>选择颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2170"/>
+        <source>Comment Tags</source>
+        <translation>注释标签</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2793"/>
+        <source>Context</source>
+        <translation>上下文</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="505"/>
+        <source>Controls</source>
+        <translation>控制</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="505"/>
+        <source>Core</source>
+        <translation>核心</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1470"/>
+        <source>LLM connector</source>
+        <translation>LLM 连接器</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1478"/>
+        <source>Warning: %1 support was not compiled into this build. Selecting this endpoint will fail when used.</source>
+        <translation>警告：此版本未编译入 %1 支持。选择此端点将在使用时失败。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2236"/>
+        <source>Custom Lints</source>
+        <translation>自定义检查</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2027"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2093"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2159"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2225"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2299"/>
+        <source>Custom color</source>
+        <translation>自定义颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="611"/>
+        <source>Dark</source>
+        <translation>深色</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1426"/>
+        <source>DeepL. Requires API key and folder ID. Configured options don&apos;t work with this endpoint, except glossary usage.</source>
+        <translation>DeepL。需要 API 密钥和文件夹 ID。除术语表使用外，配置的选项对此端点不生效。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="601"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1493"/>
+        <source>Default</source>
+        <translation>默认</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1684"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1732"/>
+        <source>Default System Prompt</source>
+        <translation>默认系统提示</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1873"/>
+        <source>Dicts: Comma-separated list of dictionaries to include words from; uses special default dictionary if this is unset.</source>
+        <translation>词典：逗号分隔的词典列表，用于包含词汇；如未设置，则使用特殊的默认词典。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1932"/>
+        <source>Disabled categories: IDs of categories to be disabled, comma-separated.</source>
+        <translation>禁用的类别：要禁用的类别 ID，逗号分隔。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1894"/>
+        <source>Disabled rules: IDs of rules to be disabled, comma-separated.</source>
+        <translation>禁用的规则：要禁用的规则 ID，逗号分隔。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="665"/>
+        <source>Display progress as percents</source>
+        <translation>以百分比显示进度</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2628"/>
+        <source>Display words/characters count for a file</source>
+        <translation>显示文件的字数/字符数</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="378"/>
+        <source>Email recorded as the commit author</source>
+        <translation>记录为提交作者身份的邮箱</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2473"/>
+        <source>Enabled</source>
+        <translation>已启用</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1901"/>
+        <source>Enabled categories: IDs of categories to be enabled, comma-separated.</source>
+        <translation>启用的类别：要启用的类别 ID，逗号分隔。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1790"/>
+        <source>Enabled only: If true, only the rules and categories whose IDs are specified with enabledRules or enabledCategories are enabled.</source>
+        <translation>仅启用：若为真，则仅启用通过 enabledRules 或 enabledCategories 指定 ID 的规则和类别。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1887"/>
+        <source>Enabled rules: IDs of rules to be enabled, comma-separated.</source>
+        <translation>启用的规则：要启用的规则 ID，逗号分隔。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="521"/>
+        <source>Endpoint %1</source>
+        <translation>端点 %1</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1092"/>
+        <source>Endpoint List</source>
+        <translation>端点列表</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="477"/>
+        <source>English</source>
+        <translation>英语</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2377"/>
+        <source>Export</source>
+        <translation>导出</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1215"/>
+        <source>Export custom lints</source>
+        <translation>导出自定义检查</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2863"/>
+        <source>File context</source>
+        <translation>文件上下文</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2832"/>
+        <source>File context select</source>
+        <translation>文件上下文选择</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="458"/>
+        <source>Frequency penalty</source>
+        <translation>频率惩罚</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1351"/>
+        <source>Getting available models failed with error: %1</source>
+        <translation>获取可用模型失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="275"/>
+        <source>Git</source>
+        <translation>Git</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="654"/>
+        <source>Given URL is invalid. Please check the validity of submitted URL.</source>
+        <translation>提供的 URL 无效。请检查所提交 URL 的有效性。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="908"/>
+        <source>Glossary Menu</source>
+        <translation>术语表菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="784"/>
+        <source>Go To Row</source>
+        <translation>转到行</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1417"/>
+        <source>Google Translate. Free and unlimited. Configured options don&apos;t work with this endpoint.</source>
+        <translation>Google Translate。免费且无限制。配置的选项对此端点不生效。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1621"/>
+        <source>High</source>
+        <translation>高</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1503"/>
+        <source>If &quot;Check key&quot; outputs something about incorrect URL, missing page etc., make sure that your base URL includes the API version. For example: &quot;https://api.openai.com/v1&quot; or &quot;https://generativelanguage.googleapis.com/v1beta&quot;. Don&apos;t include parts like &quot;/chat/completions&quot; in the URL!</source>
+        <translation>&quot;检查密钥&quot;输出关于 URL 不正确、页面缺失等错误时，请确保您的基础 URL 包含 API 版本。例如：&quot;https://api.openai.com/v1&quot; 或 &quot;https://generativelanguage.googleapis.com/v1beta&quot;。请勿在 URL 中包含 &quot;/chat/completions&quot; 等部分！</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2384"/>
+        <source>Import</source>
+        <translation>导入</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1250"/>
+        <source>Import custom lints</source>
+        <translation>导入自定义检查</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2732"/>
+        <source>In characters. Allowed range: 0-255.</source>
+        <translation>字符数。允许范围：0-255。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="204"/>
+        <source>In seconds. Range from 60 to 3600</source>
+        <translation>秒。范围 60 到 3600</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="447"/>
+        <source>Input token limit</source>
+        <translation>输入令牌限制</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="646"/>
+        <source>Interface language</source>
+        <translation>界面语言</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1215"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1250"/>
+        <source>JSON files (*.json)</source>
+        <translation>JSON 文件 (*.json)</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1434"/>
+        <source>LLM endpoint with pre-defined base URL. Don&apos;t change the base URL, unless you know what you&apos;re doing. Configured options will affect this endpoint.</source>
+        <translation>具有预定义基础 URL 的 LLM 端点。除非您知道自己在做什么，否则请勿更改基础 URL。配置的选项将影响此端点。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1769"/>
+        <source>LanguageTool</source>
+        <translation>LanguageTool</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1810"/>
+        <source>LanguageTool base URL</source>
+        <translation>LanguageTool 基础 URL</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1399"/>
+        <source>LanguageTool connection check failed with error: %1</source>
+        <translation>LanguageTool 连接检查失败，错误：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1391"/>
+        <source>LanguageTool connection check failed with error: %1
+If the server doesn&apos;t actually support HTTPS (e.g. local server, started with org.languagetool.server.HTTPServer), try an http:// URL instead.</source>
+        <translation>LanguageTool 连接检查失败，错误：%1
+如果服务器实际不支持 HTTPS（例如本地服务器，使用 org.languagetool.server.HTTPServer 启动），请改用 http:// URL。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="606"/>
+        <source>Light</source>
+        <translation>浅色</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2719"/>
+        <source>Line length hint</source>
+        <translation>行长度提示</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="856"/>
+        <source>Line length hint must be between 0 and %1.</source>
+        <translation>行长度提示必须在 0 到 %1 之间。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="877"/>
+        <source>Lint Menu</source>
+        <translation>检查菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1443"/>
+        <source>Local endpoint. You need to set correct base url, that should probably end with &apos;/v1&apos;. Configured options will affect this endpoint.</source>
+        <translation>本地端点。您需要设置正确的基础 URL，可能需要以 &apos;/v1&apos; 结尾。配置的选项将影响此端点。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1611"/>
+        <source>Low</source>
+        <translation>低</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1044"/>
+        <source>Machine Translation</source>
+        <translation>机器翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="238"/>
+        <source>Max backups</source>
+        <translation>最大备份数</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="848"/>
+        <source>Max backups must be between 1 and %1.</source>
+        <translation>最大备份数必须在 1 到 %1 之间。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1616"/>
+        <source>Medium</source>
+        <translation>中</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2400"/>
+        <source>Misc</source>
+        <translation>杂项</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1544"/>
+        <source>Model</source>
+        <translation>模型</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="625"/>
+        <source>Model that was previously selected for translation: %1 is not longer in the list of models provided by the endpoint.</source>
+        <translation>先前选择的翻译模型：%1 已不在端点提供的模型列表中。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1866"/>
+        <source>Mother tongue: A language code of the user&apos;s native language, enabling false friends checks for some language pairs.</source>
+        <translation>母语：用户母语的语言代码，为某些语言对启用易混淆词检查。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="337"/>
+        <source>Name recorded as the commit author</source>
+        <translation>记录为提交作者身份的名称</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2038"/>
+        <source>Note Tags</source>
+        <translation>备注标签</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1439"/>
+        <source>OpenAI-compatible endpoint. This category fits many providers, including OpenAI itself, DeepSeek, Mistral, OpenRouter and local providers, such as llama.cpp and koboldcpp. Requires valid base URL, that should probably end with &apos;/v1&apos;. Configured options will affect this endpoint.</source>
+        <translation>OpenAI 兼容端点。此类别适用于许多提供商，包括 OpenAI 本身、DeepSeek、Mistral、OpenRouter 以及本地提供商，如 llama.cpp 和 koboldcpp。需要有效的基础 URL，可能需要以 &apos;/v1&apos; 结尾。配置的选项将影响此端点。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="450"/>
+        <source>Output token limit</source>
+        <translation>输出令牌限制</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1269"/>
+        <source>Parsing %1 failed: %2</source>
+        <translation>解析 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2012"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2078"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2144"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2210"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2279"/>
+        <source>Pattern</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1797"/>
+        <source>Picky mode: additional rules will be activated, i.e. rules that you might only find useful when checking formal text.</source>
+        <translation>严格模式：将激活额外的规则，即只有在检查正式文本时才可能觉得有用的规则。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2104"/>
+        <source>Plugin Commands</source>
+        <translation>插件命令</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="460"/>
+        <source>Precense penalty</source>
+        <translation>存在惩罚</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="299"/>
+        <source>Prefer the repository&apos;s git config</source>
+        <translation>优先使用仓库的 git 配置</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1880"/>
+        <source>Preferred variants: Comma-separated list of preferred language variants.</source>
+        <translation>首选变体：逗号分隔的首选语言变体列表。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="505"/>
+        <source>Project</source>
+        <translation>项目</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2894"/>
+        <source>Project сontext</source>
+        <translation>项目上下文</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="245"/>
+        <source>Range from 1 to 99</source>
+        <translation>范围 1 到 99</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1259"/>
+        <source>Reading %1 failed: %2</source>
+        <translation>读取 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1603"/>
+        <source>Reasoning effort</source>
+        <translation>推理努力</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="743"/>
+        <source>Regular expression is invalid: %1. Offset: %2</source>
+        <translation>正则表达式无效：%1。偏移：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1205"/>
+        <source>Remove Selected Endpoint</source>
+        <translation>移除所选端点</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2468"/>
+        <source>Replacement</source>
+        <translation>替换</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="478"/>
+        <source>Russian</source>
+        <translation>俄语</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="722"/>
+        <source>Search Panel</source>
+        <translation>搜索面板</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1142"/>
+        <source>Select endpoints by clicking on them. You can change the name by double-clicking an endpoint.</source>
+        <translation>点击端点进行选择。双击端点可以更改名称。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2463"/>
+        <source>Sequence</source>
+        <translation>序列</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1948"/>
+        <source>Sequence Lints</source>
+        <translation>序列检查</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2421"/>
+        <source>Sequence Replacements</source>
+        <translation>序列替换</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2428"/>
+        <source>Sequence replacement is a feature that allows you to specify character sequences that will be converted into some other symbols. It&apos;s mainly useful when you need a non-ASCII punctuation symbol (e.g. em dash, guillemets).</source>
+        <translation>序列替换是一项功能，允许您指定将被转换为其他符号的字符序列。主要在需要非 ASCII 标点符号（如长破折号、引号）时有用。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1228"/>
+        <source>Serializing custom lints failed: %1</source>
+        <translation>序列化自定义检查失败：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="32"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2677"/>
+        <source>Settings</source>
+        <translation>设置</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="662"/>
+        <source>Show tab progress as a percentage instead of a translated/total count.</source>
+        <translation>以百分比显示标签页进度，而非已翻译/总数。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1712"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1725"/>
+        <source>Single Translate System Prompt</source>
+        <translation>单独翻译系统提示</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2745"/>
+        <source>Source language</source>
+        <translation>源语言</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2771"/>
+        <source>Spellcheck dictionary</source>
+        <translation>拼写检查词典</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="556"/>
+        <source>Style</source>
+        <translation>样式</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1381"/>
+        <source>Successfully connected to the LanguageTool server.</source>
+        <translation>成功连接到 LanguageTool 服务器。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2590"/>
+        <source>Symbols that should be considered space, comma-separated list of Unicode U+XXXX code points:</source>
+        <translation>应被视为空白的符号，逗号分隔的 Unicode U+XXXX 码点列表：</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1664"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1677"/>
+        <source>System Prompt</source>
+        <translation>系统提示</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="753"/>
+        <source>Tab Panel</source>
+        <translation>标签页面板</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="456"/>
+        <source>Temperature</source>
+        <translation>温度</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1969"/>
+        <source>Text Codes</source>
+        <translation>文本代码</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="593"/>
+        <source>Theme</source>
+        <translation>主题</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="453"/>
+        <source>Thinking budget limit</source>
+        <translation>思考预算限制</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1632"/>
+        <source>Thinking/reasoning</source>
+        <translation>思考/推理</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2284"/>
+        <source>Tooltip</source>
+        <translation>提示</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="462"/>
+        <source>Top P</source>
+        <translation>Top P</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="505"/>
+        <source>Translation</source>
+        <translation>翻译</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2761"/>
+        <source>Translation language</source>
+        <translation>翻译语言</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="471"/>
+        <source>Translation table font</source>
+        <translation>翻译表字体</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="465"/>
+        <source>Translation table font size</source>
+        <translation>翻译表字号</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="939"/>
+        <source>Translations Menu</source>
+        <translation>翻译菜单</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1267"/>
+        <source>Type</source>
+        <translation>类型</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2600"/>
+        <source>U+3000, U+00A0, U+200B</source>
+        <translation>U+3000, U+00A0, U+200B</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2022"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2088"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2154"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2220"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="2294"/>
+        <source>Use custom color</source>
+        <translation>使用自定义颜色</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1381"/>
+        <source>Use for single translation (will display text translation through the endpoint in translations menu)</source>
+        <translation>用于单独翻译（将在翻译菜单中通过端点显示文本翻译）</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1639"/>
+        <source>Use glossary</source>
+        <translation>使用术语表</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="296"/>
+        <source>Use the identity from the repository&apos;s own git config when it defines one, and fall back to the fields below otherwise.</source>
+        <translation>当仓库自身 git 配置定义了身份时使用它，否则回退到下面的字段。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="371"/>
+        <source>User email</source>
+        <translation>用户邮箱</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="330"/>
+        <source>User name</source>
+        <translation>用户名</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1241"/>
+        <source>Writing %1 failed: %2</source>
+        <translation>写入 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="1421"/>
+        <source>Yandex Translate. Requires API key and folder ID. Configured options don&apos;t work with this endpoint.</source>
+        <translation>Yandex Translate。需要 API 密钥和文件夹 ID。配置的选项对此端点不生效。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1441"/>
+        <source>Yandex folder ID</source>
+        <translation>Yandex 文件夹 ID</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1859"/>
+        <source>Your API key (see https://languagetool.org/editor/settings/api): Set to get Premium API access.</source>
+        <translation>您的 API 密钥（见 https://languagetool.org/editor/settings/api）：设置以获取 Premium API 访问权限。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1852"/>
+        <source>Your username/email as used to log in at languagetool.org: Set to get Premium API access.</source>
+        <translation>您在 languagetool.org 登录时使用的用户名/邮箱：设置以获取 Premium API 访问权限。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.cpp" line="678"/>
+        <source>`.dic` file corresponding to the `.aff` file does not exist. Dictionary won&apos;t work properly without the `.dic` file.</source>
+        <translation>与 `.aff` 文件对应的 `.dic` 文件不存在。没有 `.dic` 文件，词典将无法正常工作。</translation>
+    </message>
+    <message>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1483"/>
+        <location filename="../src/SettingsWindow/SettingsWindow.ui" line="1835"/>
+        <source>https://localhost:8000</source>
+        <translation>https://localhost:8000</translation>
+    </message>
+</context>
+<context>
+    <name>SourceControlDock</name>
+    <message>
+        <location filename="../src/SourceControlDock/SourceControlDock.cpp" line="77"/>
+        <source>Commit (Amend)</source>
+        <translation>提交（修正）</translation>
+    </message>
+    <message>
+        <location filename="../src/SourceControlDock/SourceControlDock.cpp" line="78"/>
+        <source>Commit and push</source>
+        <translation>提交并推送</translation>
+    </message>
+    <message>
+        <location filename="../src/SourceControlDock/SourceControlDock.cpp" line="180"/>
+        <source>Create Repository</source>
+        <translation>创建仓库</translation>
+    </message>
+    <message>
+        <location filename="../src/SourceControlDock/SourceControlDock.cpp" line="26"/>
+        <source>libgit2 returned error code %1: %2</source>
+        <translation>libgit2 返回错误码 %1：%2</translation>
+    </message>
+</context>
+<context>
+    <name>TabPanel</name>
+    <message>
+        <location filename="../src/TabPanel/TabPanel.cpp" line="38"/>
+        <source>Mark as Completed</source>
+        <translation>标记为已完成</translation>
+    </message>
+    <message>
+        <location filename="../src/TabPanel/TabPanel.cpp" line="42"/>
+        <source>Toggle Progress Display</source>
+        <translation>切换进度显示</translation>
+    </message>
+    <message>
+        <location filename="../src/TabPanel/TabPanel.cpp" line="38"/>
+        <source>Unmark Completed</source>
+        <translation>取消标记已完成</translation>
+    </message>
+</context>
+<context>
+    <name>TaskPanel</name>
+    <message>
+        <location filename="../src/TaskPanel/TaskPanel.cpp" line="57"/>
+        <source>Abort</source>
+        <translation>中止</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskPanel/TaskPanel.cpp" line="21"/>
+        <source>No tasks are running.</source>
+        <translation>没有正在运行的任务。</translation>
+    </message>
+</context>
+<context>
+    <name>TaskWorker</name>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="761"/>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="772"/>
+        <source>Exact</source>
+        <translation>精确</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="1430"/>
+        <source>Failed to parse LanguageTool response.</source>
+        <translation>解析 LanguageTool 响应失败。</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="761"/>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="772"/>
+        <source>Fuzzy (%1)</source>
+        <translation>模糊（%1）</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="1410"/>
+        <source>LanguageTool check failed: %1</source>
+        <translation>LanguageTool 检查失败：%1</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="1400"/>
+        <source>LanguageTool check skipped: set the LanguageTool base URL in settings to enable it.</source>
+        <translation>LanguageTool 检查已跳过：请在设置中设置 LanguageTool 基础 URL 以启用它。</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="1399"/>
+        <source>LanguageTool check skipped: set the translation language in settings to enable it.</source>
+        <translation>LanguageTool 检查已跳过：请在设置中设置翻译语言以启用它。</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="786"/>
+        <source>Match.</source>
+        <translation>匹配。</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="784"/>
+        <source>Number of term occurrences doesn&apos;t match the number of translation occurrences.</source>
+        <translation>术语出现次数与翻译出现次数不匹配。</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="1553"/>
+        <source>Script must define function rpgmLineCallback(sourceText, translations, filename, lineNumber, options)</source>
+        <translation>脚本必须定义函数 rpgmLineCallback(sourceText, translations, filename, lineNumber, options)</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="888"/>
+        <source>Tags do not match between source and translation.</source>
+        <translation>原文和译文之间的标签不匹配。</translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="782"/>
+        <source>Term translation is not present.</source>
+        <translation>术语翻译不存在。</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="789"/>
+        <source>Term: %1, %n occurrence(s): %2</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="780"/>
+        <source>Translation is empty.</source>
+        <translation>翻译为空。</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/TaskWorker/TaskWorker.cpp" line="792"/>
+        <source>Translation: %1, %n occurrence(s): %2</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>TermInfoCell</name>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="351"/>
+        <source>Both</source>
+        <translation>两者</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="354"/>
+        <source>Case Sensitive</source>
+        <translation>区分大小写</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="349"/>
+        <source>Exact</source>
+        <translation>精确</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="350"/>
+        <source>Fuzzy</source>
+        <translation>模糊</translation>
+    </message>
+    <message>
+        <location filename="../src/GlossaryMenu/GlossaryMenu.cpp" line="355"/>
+        <source>Permissive</source>
+        <translation>宽松</translation>
+    </message>
+</context>
+<context>
+    <name>TranslationTable</name>
+    <message>
+        <location filename="../src/TranslationTable/TranslationTable.cpp" line="113"/>
+        <source>Bookmark Row</source>
+        <translation>书签行</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/TranslationTable.cpp" line="205"/>
+        <source>Cell is not empty</source>
+        <translation>单元格非空</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/TranslationTable.cpp" line="112"/>
+        <source>Remove Row</source>
+        <translation>移除行</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/TranslationTable.cpp" line="206"/>
+        <source>Selected cell is not empty. Overwrite its contents with the translation?</source>
+        <translation>所选单元格非空。要用翻译覆盖其内容吗？</translation>
+    </message>
+    <message>
+        <location filename="../src/TranslationTable/TranslationTable.cpp" line="131"/>
+        <source>Translation</source>
+        <translation>翻译</translation>
+    </message>
+</context>
+<context>
+    <name>TranslationsMenu</name>
+    <message>
+        <location filename="../src/TranslationsMenu/TranslationsMenu.cpp" line="34"/>
+        <source>Translations Menu</source>
+        <translation>翻译菜单</translation>
+    </message>
+</context>
+<context>
+    <name>Utils</name>
+    <message>
+        <location filename="../src/utilities/Utils.cpp" line="440"/>
+        <source>Failed to decrypt icon set %1: %2</source>
+        <translation>解密图标集 %1 失败：%2</translation>
+    </message>
+    <message>
+        <location filename="../src/utilities/Utils.cpp" line="372"/>
+        <location filename="../src/utilities/Utils.cpp" line="417"/>
+        <source>Failed to open file %1: %2</source>
+        <translation>打开文件 %1 失败：%2</translation>
+    </message>
+</context>
+<context>
+    <name>WriteMenu</name>
+    <message>
+        <location filename="../src/WriteMenu/WriteMenu.ui" line="41"/>
+        <source>Apply</source>
+        <translation>应用</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Adds Simplified Chinese translation for both the application UI strings and the README, based on upstream v1.1.0.

## Summary

- **translations/rpgmtranslate.zh-CN.ts** — 543 application strings fully translated (0 unfinished)
- **README.zh-CN.md** — Complete translation of all README sections
- **Language menu** — Chinese (Simplified) added to both the top menu bar and Settings page language selector
- **Cross-link READMEs** — English, Russian, and Chinese READMEs now link to each other

## Checklist

- [x] Application strings: 543 translated, 0 unfinished
- [x] README: all sections translated
- [x] Based on upstream v1.1.0 (7b56c5b)